### PR TITLE
fix(repo-server): excess git requests, improve cache performance by adding two level cache

### DIFF
--- a/cmd/argocd/commands/headless/headless.go
+++ b/cmd/argocd/commands/headless/headless.go
@@ -78,9 +78,9 @@ func (c *forwardCacheClient) Set(item *cache.Item) error {
 	})
 }
 
-func (c *forwardCacheClient) Get(key string, obj interface{}) error {
+func (c *forwardCacheClient) Get(item *cache.Item) error {
 	return c.doLazy(func(client cache.CacheClient) error {
-		return client.Get(key, obj)
+		return client.Get(item)
 	})
 }
 

--- a/reposerver/cache/cache.go
+++ b/reposerver/cache/cache.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/argoproj/gitops-engine/pkg/utils/text"
 	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/google/uuid"
 	"github.com/redis/go-redis/v9"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -25,11 +26,13 @@ import (
 )
 
 var ErrCacheMiss = cacheutil.ErrCacheMiss
+var ErrCacheKeyLocked = cacheutil.ErrCacheKeyLocked
 
 type Cache struct {
-	cache                   *cacheutil.Cache
-	repoCacheExpiration     time.Duration
-	revisionCacheExpiration time.Duration
+	cache                    *cacheutil.Cache
+	repoCacheExpiration      time.Duration
+	revisionCacheExpiration  time.Duration
+	revisionCacheLockTimeout time.Duration
 }
 
 // ClusterRuntimeInfo holds cluster runtime information
@@ -41,7 +44,7 @@ type ClusterRuntimeInfo interface {
 }
 
 func NewCache(cache *cacheutil.Cache, repoCacheExpiration time.Duration, revisionCacheExpiration time.Duration) *Cache {
-	return &Cache{cache, repoCacheExpiration, revisionCacheExpiration}
+	return &Cache{cache, repoCacheExpiration, revisionCacheExpiration, 10 * time.Second}
 }
 
 func AddCacheFlagsToCmd(cmd *cobra.Command, opts ...func(client *redis.Client)) func() (*Cache, error) {
@@ -141,12 +144,17 @@ func listApps(repoURL, revision string) string {
 
 func (c *Cache) ListApps(repoUrl, revision string) (map[string]string, error) {
 	res := make(map[string]string)
-	err := c.cache.GetItem(listApps(repoUrl, revision), &res)
+	err := c.cache.GetItem(listApps(repoUrl, revision), &res, nil)
 	return res, err
 }
 
 func (c *Cache) SetApps(repoUrl, revision string, apps map[string]string) error {
-	return c.cache.SetItem(listApps(repoUrl, revision), apps, c.repoCacheExpiration, apps == nil)
+	return c.cache.SetItem(
+		listApps(repoUrl, revision),
+		apps,
+		&cacheutil.CacheActionOpts{
+			Expiration: c.repoCacheExpiration,
+			Delete:     apps == nil})
 }
 
 func helmIndexRefsKey(repo string) string {
@@ -155,12 +163,19 @@ func helmIndexRefsKey(repo string) string {
 
 // SetHelmIndex stores helm repository index.yaml content to cache
 func (c *Cache) SetHelmIndex(repo string, indexData []byte) error {
-	return c.cache.SetItem(helmIndexRefsKey(repo), indexData, c.revisionCacheExpiration, false)
+	if indexData == nil {
+		// Logged as warning upstream
+		return fmt.Errorf("helm index data is nil, skipping cache")
+	}
+	return c.cache.SetItem(
+		helmIndexRefsKey(repo),
+		indexData,
+		&cacheutil.CacheActionOpts{Expiration: c.revisionCacheExpiration})
 }
 
 // GetHelmIndex retrieves helm repository index.yaml content from cache
 func (c *Cache) GetHelmIndex(repo string, indexData *[]byte) error {
-	return c.cache.GetItem(helmIndexRefsKey(repo), indexData)
+	return c.cache.GetItem(helmIndexRefsKey(repo), indexData, nil)
 }
 
 func gitRefsKey(repo string) string {
@@ -173,21 +188,108 @@ func (c *Cache) SetGitReferences(repo string, references []*plumbing.Reference) 
 	for i := range references {
 		input = append(input, references[i].Strings())
 	}
-	return c.cache.SetItem(gitRefsKey(repo), input, c.revisionCacheExpiration, false)
+	return c.cache.SetItem(gitRefsKey(repo), input, &cacheutil.CacheActionOpts{Expiration: c.revisionCacheExpiration})
 }
 
-// GetGitReferences retrieves resolved Git repository references from cache
-func (c *Cache) GetGitReferences(repo string, references *[]*plumbing.Reference) error {
-	var input [][2]string
-	if err := c.cache.GetItem(gitRefsKey(repo), &input); err != nil {
-		return err
-	}
+func GitRefCacheItemToReferences(cacheItem [][2]string) *[]*plumbing.Reference {
 	var res []*plumbing.Reference
-	for i := range input {
-		res = append(res, plumbing.NewReferenceFromStrings(input[i][0], input[i][1]))
+	for i := range cacheItem {
+		// Skip empty data
+		if cacheItem[i][0] != "" || cacheItem[i][1] != "" {
+			res = append(res, plumbing.NewReferenceFromStrings(cacheItem[i][0], cacheItem[i][1]))
+		}
 	}
-	*references = res
-	return nil
+	return &res
+}
+
+// TryLockGitRefCache attempts to lock the key for the Git repository references if the key doesn't exist
+func (c *Cache) TryLockGitRefCache(repo string, lockId string) error {
+	// This try set with DisableOverwrite is important for making sure that only one process is able to claim ownership
+	// A normal get + set, or just set would cause ownership to go to whoever the last writer was, and during race conditions
+	// leads to duplicate requests
+	err := c.cache.SetItem(gitRefsKey(repo), [][2]string{{cacheutil.CacheLockedValue, lockId}}, &cacheutil.CacheActionOpts{
+		Expiration:       c.revisionCacheLockTimeout,
+		DisableOverwrite: true})
+	return err
+}
+
+func (c *Cache) GetGitReferences(repo string, lockId string) (lockOwner string, references *[]*plumbing.Reference, err error) {
+	var input [][2]string
+	err = c.cache.GetItem(gitRefsKey(repo), &input, &cacheutil.CacheActionOpts{Expiration: c.revisionCacheExpiration})
+	log.Errorf("Error: %v", err)
+	if err == ErrCacheMiss {
+		// Expected
+		return "", nil, nil
+	} else if err == nil && len(input) > 0 && len(input[0]) > 0 {
+		if input[0][0] != cacheutil.CacheLockedValue {
+			// Valid value in cache, convert to plumbing.Reference and return
+			return "", GitRefCacheItemToReferences(input), nil
+		} else {
+			// The key lock is being held
+			return input[0][1], nil, nil
+		}
+	}
+	return "", nil, err
+}
+
+// GetOrLockGitReferences retrieves the git references if they exist, otherwise creates a lock and returns so the caller can populate the cache
+func (c *Cache) GetOrLockGitReferences(repo string, references *[]*plumbing.Reference) (updateCache bool, lockId string, err error) {
+	myLockUUID, err := uuid.NewRandom()
+	if err != nil {
+		log.Debug("Error generating git references cache lock id: ", err)
+		return false, "", err
+	}
+	// We need to be able to identify that our lock was the successful one, otherwise we'll still have duplicate requests
+	myLockId := myLockUUID.String()
+	// Value matches the ttl on the lock in TryLockGitRefCache
+	waitUntil := time.Now().Add(c.revisionCacheLockTimeout)
+	// Wait only the maximum amount of time configured for the lock
+	for time.Now().Before(waitUntil) {
+		// Attempt to retrieve the key from local cache only
+		if _, cacheReferences, err := c.GetGitReferences(repo, myLockId); err != nil || cacheReferences != nil {
+			if cacheReferences != nil {
+				*references = *cacheReferences
+			}
+			return false, myLockId, err
+		}
+		// Could not get key locally attempt to get the lock
+		err = c.TryLockGitRefCache(repo, myLockId)
+		if err != nil {
+			// Log but ignore this error since we'll want to retry, failing to obtain the lock should not throw an error
+			log.Errorf("Error attempting to acquire git references cache lock: %v", err)
+		}
+		// Attempt to retrieve the key again to see if we have the lock, or the key was populated
+		if lockOwner, cacheReferences, err := c.GetGitReferences(repo, myLockId); err != nil || cacheReferences != nil {
+			if cacheReferences != nil {
+				// Someone else populated the key
+				*references = *cacheReferences
+			}
+			return false, myLockId, err
+		} else if lockOwner == myLockId {
+			// We have the lock, populate the key
+			return true, myLockId, nil
+		}
+		// Wait for lock, valid value, or timeout
+		time.Sleep(1 * time.Second)
+	}
+	// Timeout waiting for lock
+	log.Debug("Repository cache was unable to acquire lock or valid data within timeout")
+	return true, myLockId, nil
+}
+
+// UnlockGitReferences unlocks the key for the Git repository references if needed
+func (c *Cache) UnlockGitReferences(repo string, lockId string) error {
+	var input [][2]string
+	var err error
+	if err = c.cache.GetItem(gitRefsKey(repo), &input, nil); err == nil &&
+		len(input) > 0 &&
+		len(input[0]) > 1 &&
+		input[0][0] == cacheutil.CacheLockedValue &&
+		input[0][1] == lockId {
+		// We have the lock, so remove it
+		return c.cache.SetItem(gitRefsKey(repo), input, &cacheutil.CacheActionOpts{Delete: true})
+	}
+	return err
 }
 
 // refSourceCommitSHAs is a list of resolved revisions for each ref source. This allows us to invalidate the cache
@@ -226,7 +328,7 @@ func LogDebugManifestCacheKeyFields(message string, reason string, revision stri
 }
 
 func (c *Cache) GetManifests(revision string, appSrc *appv1.ApplicationSource, srcRefs appv1.RefTargetRevisionMapping, clusterInfo ClusterRuntimeInfo, namespace string, trackingMethod string, appLabelKey string, appName string, res *CachedManifestResponse, refSourceCommitSHAs ResolvedRevisions) error {
-	err := c.cache.GetItem(manifestCacheKey(revision, appSrc, srcRefs, namespace, trackingMethod, appLabelKey, appName, clusterInfo, refSourceCommitSHAs), res)
+	err := c.cache.GetItem(manifestCacheKey(revision, appSrc, srcRefs, namespace, trackingMethod, appLabelKey, appName, clusterInfo, refSourceCommitSHAs), res, nil)
 
 	if err != nil {
 		return err
@@ -269,11 +371,19 @@ func (c *Cache) SetManifests(revision string, appSrc *appv1.ApplicationSource, s
 		res.CacheEntryHash = hash
 	}
 
-	return c.cache.SetItem(manifestCacheKey(revision, appSrc, srcRefs, namespace, trackingMethod, appLabelKey, appName, clusterInfo, refSourceCommitSHAs), res, c.repoCacheExpiration, res == nil)
+	return c.cache.SetItem(
+		manifestCacheKey(revision, appSrc, srcRefs, namespace, trackingMethod, appLabelKey, appName, clusterInfo, refSourceCommitSHAs),
+		res,
+		&cacheutil.CacheActionOpts{
+			Expiration: c.repoCacheExpiration,
+			Delete:     res == nil})
 }
 
 func (c *Cache) DeleteManifests(revision string, appSrc *appv1.ApplicationSource, srcRefs appv1.RefTargetRevisionMapping, clusterInfo ClusterRuntimeInfo, namespace, trackingMethod, appLabelKey, appName string, refSourceCommitSHAs ResolvedRevisions) error {
-	return c.cache.SetItem(manifestCacheKey(revision, appSrc, srcRefs, namespace, trackingMethod, appLabelKey, appName, clusterInfo, refSourceCommitSHAs), "", c.repoCacheExpiration, true)
+	return c.cache.SetItem(
+		manifestCacheKey(revision, appSrc, srcRefs, namespace, trackingMethod, appLabelKey, appName, clusterInfo, refSourceCommitSHAs),
+		"",
+		&cacheutil.CacheActionOpts{Delete: true})
 }
 
 func appDetailsCacheKey(revision string, appSrc *appv1.ApplicationSource, srcRefs appv1.RefTargetRevisionMapping, trackingMethod appv1.TrackingMethod, refSourceCommitSHAs ResolvedRevisions) string {
@@ -284,11 +394,16 @@ func appDetailsCacheKey(revision string, appSrc *appv1.ApplicationSource, srcRef
 }
 
 func (c *Cache) GetAppDetails(revision string, appSrc *appv1.ApplicationSource, srcRefs appv1.RefTargetRevisionMapping, res *apiclient.RepoAppDetailsResponse, trackingMethod appv1.TrackingMethod, refSourceCommitSHAs ResolvedRevisions) error {
-	return c.cache.GetItem(appDetailsCacheKey(revision, appSrc, srcRefs, trackingMethod, refSourceCommitSHAs), res)
+	return c.cache.GetItem(appDetailsCacheKey(revision, appSrc, srcRefs, trackingMethod, refSourceCommitSHAs), res, nil)
 }
 
 func (c *Cache) SetAppDetails(revision string, appSrc *appv1.ApplicationSource, srcRefs appv1.RefTargetRevisionMapping, res *apiclient.RepoAppDetailsResponse, trackingMethod appv1.TrackingMethod, refSourceCommitSHAs ResolvedRevisions) error {
-	return c.cache.SetItem(appDetailsCacheKey(revision, appSrc, srcRefs, trackingMethod, refSourceCommitSHAs), res, c.repoCacheExpiration, res == nil)
+	return c.cache.SetItem(
+		appDetailsCacheKey(revision, appSrc, srcRefs, trackingMethod, refSourceCommitSHAs),
+		res,
+		&cacheutil.CacheActionOpts{
+			Expiration: c.repoCacheExpiration,
+			Delete:     res == nil})
 }
 
 func revisionMetadataKey(repoURL, revision string) string {
@@ -297,11 +412,14 @@ func revisionMetadataKey(repoURL, revision string) string {
 
 func (c *Cache) GetRevisionMetadata(repoURL, revision string) (*appv1.RevisionMetadata, error) {
 	item := &appv1.RevisionMetadata{}
-	return item, c.cache.GetItem(revisionMetadataKey(repoURL, revision), item)
+	return item, c.cache.GetItem(revisionMetadataKey(repoURL, revision), item, nil)
 }
 
 func (c *Cache) SetRevisionMetadata(repoURL, revision string, item *appv1.RevisionMetadata) error {
-	return c.cache.SetItem(revisionMetadataKey(repoURL, revision), item, c.repoCacheExpiration, false)
+	return c.cache.SetItem(
+		revisionMetadataKey(repoURL, revision),
+		item,
+		&cacheutil.CacheActionOpts{Expiration: c.repoCacheExpiration})
 }
 
 func revisionChartDetailsKey(repoURL, chart, revision string) string {
@@ -310,11 +428,14 @@ func revisionChartDetailsKey(repoURL, chart, revision string) string {
 
 func (c *Cache) GetRevisionChartDetails(repoURL, chart, revision string) (*appv1.ChartDetails, error) {
 	item := &appv1.ChartDetails{}
-	return item, c.cache.GetItem(revisionChartDetailsKey(repoURL, chart, revision), item)
+	return item, c.cache.GetItem(revisionChartDetailsKey(repoURL, chart, revision), item, nil)
 }
 
 func (c *Cache) SetRevisionChartDetails(repoURL, chart, revision string, item *appv1.ChartDetails) error {
-	return c.cache.SetItem(revisionChartDetailsKey(repoURL, chart, revision), item, c.repoCacheExpiration, false)
+	return c.cache.SetItem(
+		revisionChartDetailsKey(repoURL, chart, revision),
+		item,
+		&cacheutil.CacheActionOpts{Expiration: c.repoCacheExpiration})
 }
 
 func gitFilesKey(repoURL, revision, pattern string) string {
@@ -322,12 +443,15 @@ func gitFilesKey(repoURL, revision, pattern string) string {
 }
 
 func (c *Cache) SetGitFiles(repoURL, revision, pattern string, files map[string][]byte) error {
-	return c.cache.SetItem(gitFilesKey(repoURL, revision, pattern), &files, c.repoCacheExpiration, false)
+	return c.cache.SetItem(
+		gitFilesKey(repoURL, revision, pattern),
+		&files,
+		&cacheutil.CacheActionOpts{Expiration: c.repoCacheExpiration})
 }
 
 func (c *Cache) GetGitFiles(repoURL, revision, pattern string) (map[string][]byte, error) {
 	var item map[string][]byte
-	return item, c.cache.GetItem(gitFilesKey(repoURL, revision, pattern), &item)
+	return item, c.cache.GetItem(gitFilesKey(repoURL, revision, pattern), &item, nil)
 }
 
 func gitDirectoriesKey(repoURL, revision string) string {
@@ -335,12 +459,15 @@ func gitDirectoriesKey(repoURL, revision string) string {
 }
 
 func (c *Cache) SetGitDirectories(repoURL, revision string, directories []string) error {
-	return c.cache.SetItem(gitDirectoriesKey(repoURL, revision), &directories, c.repoCacheExpiration, false)
+	return c.cache.SetItem(
+		gitDirectoriesKey(repoURL, revision),
+		&directories,
+		&cacheutil.CacheActionOpts{Expiration: c.repoCacheExpiration})
 }
 
 func (c *Cache) GetGitDirectories(repoURL, revision string) ([]string, error) {
 	var item []string
-	return item, c.cache.GetItem(gitDirectoriesKey(repoURL, revision), &item)
+	return item, c.cache.GetItem(gitDirectoriesKey(repoURL, revision), &item, nil)
 }
 
 func (cmr *CachedManifestResponse) shallowCopy() *CachedManifestResponse {

--- a/reposerver/cache/cache_test.go
+++ b/reposerver/cache/cache_test.go
@@ -3,35 +3,48 @@ package cache
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
 
+	. "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+	appv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/argo-cd/v2/reposerver/apiclient"
+	"github.com/argoproj/argo-cd/v2/reposerver/cache/mocks"
+	cacheutil "github.com/argoproj/argo-cd/v2/util/cache"
+	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
-
-	. "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
-	"github.com/argoproj/argo-cd/v2/reposerver/apiclient"
-	cacheutil "github.com/argoproj/argo-cd/v2/util/cache"
+	"github.com/stretchr/testify/mock"
 )
 
-type fixtures struct {
+type MockedCache struct {
+	mock.Mock
 	*Cache
 }
 
+type fixtures struct {
+	mockCache *mocks.MockRepoCache
+	cache     *MockedCache
+}
+
 func newFixtures() *fixtures {
-	return &fixtures{NewCache(
-		cacheutil.NewCache(cacheutil.NewInMemoryCache(1*time.Hour)),
-		1*time.Minute,
-		1*time.Minute,
-	)}
+	mockCache := mocks.NewMockRepoCache(&mocks.MockCacheOptions{RevisionCacheExpiration: 1 * time.Minute, RepoCacheExpiration: 1 * time.Minute})
+	newBaseCache := cacheutil.NewCache(mockCache.RedisClient)
+	baseCache := NewCache(newBaseCache, 1*time.Minute, 1*time.Minute)
+	return &fixtures{mockCache: mockCache, cache: &MockedCache{Cache: baseCache}}
 }
 
 func TestCache_GetRevisionMetadata(t *testing.T) {
-	cache := newFixtures().Cache
+	fixtures := newFixtures()
+	t.Cleanup(fixtures.mockCache.StopRedisCallback)
+	cache := fixtures.cache
+	mockCache := fixtures.mockCache
 	// cache miss
 	_, err := cache.GetRevisionMetadata("my-repo-url", "my-revision")
 	assert.Equal(t, ErrCacheMiss, err)
+	mockCache.RedisClient.AssertCalled(t, "Get", mock.Anything, mock.Anything)
 	// populate cache
 	err = cache.SetRevisionMetadata("my-repo-url", "my-revision", &RevisionMetadata{Message: "my-message"})
 	assert.NoError(t, err)
@@ -45,10 +58,14 @@ func TestCache_GetRevisionMetadata(t *testing.T) {
 	value, err := cache.GetRevisionMetadata("my-repo-url", "my-revision")
 	assert.NoError(t, err)
 	assert.Equal(t, &RevisionMetadata{Message: "my-message"}, value)
+	mockCache.AssertCacheCalledTimes(t, &mocks.CacheCallCounts{ExternalSets: 1, ExternalGets: 4})
 }
 
 func TestCache_ListApps(t *testing.T) {
-	cache := newFixtures().Cache
+	fixtures := newFixtures()
+	t.Cleanup(fixtures.mockCache.StopRedisCallback)
+	cache := fixtures.cache
+	mockCache := fixtures.mockCache
 	// cache miss
 	_, err := cache.ListApps("my-repo-url", "my-revision")
 	assert.Equal(t, ErrCacheMiss, err)
@@ -65,10 +82,14 @@ func TestCache_ListApps(t *testing.T) {
 	value, err := cache.ListApps("my-repo-url", "my-revision")
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]string{"foo": "bar"}, value)
+	mockCache.AssertCacheCalledTimes(t, &mocks.CacheCallCounts{ExternalSets: 1, ExternalGets: 4})
 }
 
 func TestCache_GetManifests(t *testing.T) {
-	cache := newFixtures().Cache
+	fixtures := newFixtures()
+	t.Cleanup(fixtures.mockCache.StopRedisCallback)
+	cache := fixtures.cache
+	mockCache := fixtures.mockCache
 	// cache miss
 	q := &apiclient.ManifestRequest{}
 	value := &CachedManifestResponse{}
@@ -107,10 +128,14 @@ func TestCache_GetManifests(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, &CachedManifestResponse{ManifestResponse: &apiclient.ManifestResponse{SourceType: "my-source-type"}}, value)
 	})
+	mockCache.AssertCacheCalledTimes(t, &mocks.CacheCallCounts{ExternalSets: 1, ExternalGets: 8})
 }
 
 func TestCache_GetAppDetails(t *testing.T) {
-	cache := newFixtures().Cache
+	fixtures := newFixtures()
+	t.Cleanup(fixtures.mockCache.StopRedisCallback)
+	cache := fixtures.cache
+	mockCache := fixtures.mockCache
 	// cache miss
 	value := &apiclient.RepoAppDetailsResponse{}
 	emptyRefSources := map[string]*RefTarget{}
@@ -129,6 +154,7 @@ func TestCache_GetAppDetails(t *testing.T) {
 	err = cache.GetAppDetails("my-revision", &ApplicationSource{}, emptyRefSources, value, "", nil)
 	assert.NoError(t, err)
 	assert.Equal(t, &apiclient.RepoAppDetailsResponse{Type: "my-type"}, value)
+	mockCache.AssertCacheCalledTimes(t, &mocks.CacheCallCounts{ExternalSets: 1, ExternalGets: 4})
 }
 
 func TestAddCacheFlagsToCmd(t *testing.T) {
@@ -307,5 +333,428 @@ func TestCachedManifestResponse_ShallowCopyExpectedFields(t *testing.T) {
 	for _, expectedField := range expectedFields {
 		assert.Truef(t, strings.Contains(string(str), "\""+expectedField+"\""), "Missing field: %s", expectedField)
 	}
+
+}
+
+func TestGetGitReferences(t *testing.T) {
+	t.Run("Valid args, nothing in cache, in-memory only", func(t *testing.T) {
+		fixtures := newFixtures()
+		t.Cleanup(fixtures.mockCache.StopRedisCallback)
+		cache := fixtures.cache
+		lockOwner, references, err := cache.GetGitReferences("test-repo", "test-lock-id")
+		assert.NoError(t, err, "Error is cache miss handled inside function")
+		assert.Equal(t, "", lockOwner, "Lock owner should be empty")
+		assert.Nil(t, references)
+		fixtures.mockCache.AssertCacheCalledTimes(t, &mocks.CacheCallCounts{ExternalGets: 1})
+	})
+
+	t.Run("Valid args, nothing in cache, external only", func(t *testing.T) {
+		fixtures := newFixtures()
+		t.Cleanup(fixtures.mockCache.StopRedisCallback)
+		cache := fixtures.cache
+		lockOwner, references, err := cache.GetGitReferences("test-repo", "test-lock-id")
+		assert.NoError(t, err, "Error is cache miss handled inside function")
+		assert.Equal(t, "", lockOwner, "Lock owner should be empty")
+		assert.Nil(t, references)
+		fixtures.mockCache.AssertCacheCalledTimes(t, &mocks.CacheCallCounts{ExternalGets: 1})
+	})
+
+	t.Run("Valid args, value in cache, in-memory only", func(t *testing.T) {
+		fixtures := newFixtures()
+		t.Cleanup(fixtures.mockCache.StopRedisCallback)
+		cache := fixtures.cache
+		err := cache.SetGitReferences("test-repo", *GitRefCacheItemToReferences([][2]string{{"test-repo", "ref: test"}}))
+		assert.NoError(t, err)
+		lockOwner, references, err := cache.GetGitReferences("test-repo", "test-lock-id")
+		assert.NoError(t, err)
+		assert.Equal(t, "", lockOwner, "Lock owner should be empty")
+		assert.Equal(t, 1, len(*references))
+		assert.Equal(t, "test", (*references)[0].Target().String())
+		assert.Equal(t, "test-repo", (*references)[0].Name().String())
+		fixtures.mockCache.AssertCacheCalledTimes(t, &mocks.CacheCallCounts{ExternalSets: 1, ExternalGets: 1})
+	})
+
+	t.Run("cache error", func(t *testing.T) {
+		fixtures := newFixtures()
+		t.Cleanup(fixtures.mockCache.StopRedisCallback)
+		cache := fixtures.cache
+		fixtures.mockCache.RedisClient.On("Get", mock.Anything, mock.Anything).Unset()
+		fixtures.mockCache.RedisClient.On("Get", mock.Anything, mock.Anything).Return(errors.New("test cache error"))
+		lockOwner, references, err := cache.GetGitReferences("test-repo", "test-lock-id")
+		assert.ErrorContains(t, err, "test cache error", "Error should be propagated")
+		assert.Equal(t, "", lockOwner, "Lock owner should be empty")
+		assert.Nil(t, references)
+		fixtures.mockCache.AssertCacheCalledTimes(t, &mocks.CacheCallCounts{ExternalGets: 1})
+	})
+
+}
+
+func TestGitRefCacheItemToReferences_DataChecks(t *testing.T) {
+	references := *GitRefCacheItemToReferences(nil)
+	assert.Equal(t, 0, len(references), "No data should be handled gracefully by returning an empty slice")
+	references = *GitRefCacheItemToReferences([][2]string{{"", ""}})
+	assert.Equal(t, 0, len(references), "Empty data should be discarded")
+	references = *GitRefCacheItemToReferences([][2]string{{"test", ""}})
+	assert.Equal(t, 1, len(references), "Just the key being set should not be discarded")
+	assert.Equal(t, "test", references[0].Name().String(), "Name should be set and equal test")
+	references = *GitRefCacheItemToReferences([][2]string{{"", "ref: test1"}})
+	assert.Equal(t, 1, len(references), "Just the value being set should not be discarded")
+	assert.Equal(t, "test1", references[0].Target().String(), "Target should be set and equal test1")
+	references = *GitRefCacheItemToReferences([][2]string{{"test2", "ref: test2"}})
+	assert.Equal(t, 1, len(references), "Valid data is should be preserved")
+	assert.Equal(t, "test2", references[0].Name().String(), "Name should be set and equal test2")
+	assert.Equal(t, "test2", references[0].Target().String(), "Target should be set and equal test2")
+	references = *GitRefCacheItemToReferences([][2]string{{"test3", "ref: test3"}, {"test4", "ref: test4"}})
+	assert.Equal(t, 2, len(references), "Valid data is should be preserved")
+	assert.Equal(t, "test3", references[0].Name().String(), "Name should be set and equal test3")
+	assert.Equal(t, "test3", references[0].Target().String(), "Target should be set and equal test3")
+	assert.Equal(t, "test4", references[1].Name().String(), "Name should be set and equal test4")
+	assert.Equal(t, "test4", references[1].Target().String(), "Target should be set and equal test4")
+}
+
+func TestTryLockGitRefCache_OwnershipFlows(t *testing.T) {
+	fixtures := newFixtures()
+	t.Cleanup(fixtures.mockCache.StopRedisCallback)
+	cache := fixtures.cache
+	utilCache := cache.cache
+	// Test setting the lock
+	err := cache.TryLockGitRefCache("my-repo-url", "my-lock-id")
+	fixtures.mockCache.AssertCacheCalledTimes(t, &mocks.CacheCallCounts{ExternalSets: 1})
+	assert.NoError(t, err)
+	var output [][2]string
+	key := fmt.Sprintf("git-refs|%s", "my-repo-url")
+	err = utilCache.GetItem(key, &output, nil)
+	fixtures.mockCache.AssertCacheCalledTimes(t, &mocks.CacheCallCounts{ExternalSets: 1, ExternalGets: 1})
+	assert.NoError(t, err)
+	assert.Equal(t, "locked", output[0][0], "The lock should be set")
+	assert.Equal(t, "my-lock-id", output[0][1], "The lock should be set to the provided lock id")
+	// Test not being able to overwrite the lock
+	err = cache.TryLockGitRefCache("my-repo-url", "other-lock-id")
+	fixtures.mockCache.AssertCacheCalledTimes(t, &mocks.CacheCallCounts{ExternalSets: 2, ExternalGets: 1})
+	assert.NoError(t, err)
+	err = utilCache.GetItem(key, &output, nil)
+	fixtures.mockCache.AssertCacheCalledTimes(t, &mocks.CacheCallCounts{ExternalSets: 2, ExternalGets: 2})
+	assert.NoError(t, err)
+	assert.Equal(t, "locked", output[0][0], "The lock should not have changed")
+	assert.Equal(t, "my-lock-id", output[0][1], "The lock should not have changed")
+	// Test can overwrite once there is nothing set
+	err = utilCache.SetItem(key, [][2]string{}, &cacheutil.CacheActionOpts{Expiration: 0, Delete: true})
+	fixtures.mockCache.AssertCacheCalledTimes(t, &mocks.CacheCallCounts{ExternalSets: 2, ExternalGets: 2, ExternalDeletes: 1})
+	assert.NoError(t, err)
+	err = cache.TryLockGitRefCache("my-repo-url", "other-lock-id")
+	fixtures.mockCache.AssertCacheCalledTimes(t, &mocks.CacheCallCounts{ExternalSets: 3, ExternalGets: 2, ExternalDeletes: 1})
+	assert.NoError(t, err)
+	err = utilCache.GetItem(key, &output, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, "locked", output[0][0], "The lock should be set")
+	assert.Equal(t, "other-lock-id", output[0][1], "The lock id should have changed to other-lock-id")
+	fixtures.mockCache.AssertCacheCalledTimes(t, &mocks.CacheCallCounts{ExternalSets: 3, ExternalGets: 3, ExternalDeletes: 1})
+}
+
+func TestGetOrLockGitReferences(t *testing.T) {
+	t.Run("Test cache lock get lock", func(t *testing.T) {
+		fixtures := newFixtures()
+		t.Cleanup(fixtures.mockCache.StopRedisCallback)
+		cache := fixtures.cache
+		var references []*plumbing.Reference
+		updateCache, lockId, err := cache.GetOrLockGitReferences("test-repo", &references)
+		assert.NoError(t, err)
+		assert.True(t, updateCache)
+		assert.NotEqual(t, "", lockId, "Lock id should be set")
+		fixtures.mockCache.AssertCacheCalledTimes(t, &mocks.CacheCallCounts{ExternalSets: 1, ExternalGets: 2})
+	})
+
+	t.Run("Test cache lock, cache hit local", func(t *testing.T) {
+		fixtures := newFixtures()
+		t.Cleanup(fixtures.mockCache.StopRedisCallback)
+		cache := fixtures.cache
+		err := cache.SetGitReferences("test-repo", *GitRefCacheItemToReferences([][2]string{{"test-repo", "ref: test"}}))
+		assert.NoError(t, err)
+		var references []*plumbing.Reference
+		updateCache, lockId, err := cache.GetOrLockGitReferences("test-repo", &references)
+		assert.NoError(t, err)
+		assert.False(t, updateCache)
+		assert.NotEqual(t, "", lockId, "Lock id should be set")
+		assert.Equal(t, "test-repo", references[0].Name().String())
+		assert.Equal(t, "test", references[0].Target().String())
+		fixtures.mockCache.AssertCacheCalledTimes(t, &mocks.CacheCallCounts{ExternalSets: 1, ExternalGets: 1})
+	})
+
+	t.Run("Test cache lock, cache hit remote", func(t *testing.T) {
+		fixtures := newFixtures()
+		t.Cleanup(fixtures.mockCache.StopRedisCallback)
+		cache := fixtures.cache
+		err := fixtures.cache.cache.SetItem(
+			"git-refs|test-repo",
+			[][2]string{{"test-repo", "ref: test"}},
+			&cacheutil.CacheActionOpts{
+				Expiration: 30 * time.Second})
+		assert.NoError(t, err)
+		var references []*plumbing.Reference
+		updateCache, lockId, err := cache.GetOrLockGitReferences("test-repo", &references)
+		assert.NoError(t, err)
+		assert.False(t, updateCache)
+		assert.NotEqual(t, "", lockId, "Lock id should be set")
+		assert.Equal(t, "test-repo", references[0].Name().String())
+		assert.Equal(t, "test", references[0].Target().String())
+		fixtures.mockCache.AssertCacheCalledTimes(t, &mocks.CacheCallCounts{ExternalSets: 1, ExternalGets: 1})
+	})
+
+	t.Run("Test miss, populated by external", func(t *testing.T) {
+		// Tests the case where another process populates the external cache when trying
+		// to obtain the lock
+		fixtures := newFixtures()
+		t.Cleanup(fixtures.mockCache.StopRedisCallback)
+		cache := fixtures.cache
+		fixtures.mockCache.RedisClient.On("Get", mock.Anything, mock.Anything).Unset()
+		fixtures.mockCache.RedisClient.On("Get", mock.Anything, mock.Anything).Return(cacheutil.ErrCacheMiss).Once().Run(func(args mock.Arguments) {
+			err := cache.SetGitReferences("test-repo", *GitRefCacheItemToReferences([][2]string{{"test-repo", "ref: test"}}))
+			assert.NoError(t, err)
+		}).On("Get", mock.Anything, mock.Anything).Return(nil)
+		var references []*plumbing.Reference
+		updateCache, lockId, err := cache.GetOrLockGitReferences("test-repo", &references)
+		assert.NoError(t, err)
+		assert.False(t, updateCache)
+		assert.NotEqual(t, "", lockId, "Lock id should be set")
+		fixtures.mockCache.AssertCacheCalledTimes(t, &mocks.CacheCallCounts{ExternalSets: 2, ExternalGets: 2})
+	})
+
+	t.Run("Test cache lock timeout", func(t *testing.T) {
+		fixtures := newFixtures()
+		t.Cleanup(fixtures.mockCache.StopRedisCallback)
+		cache := fixtures.cache
+		// Create conditions for cache hit, which would result in false on updateCache if we weren't reaching the timeout
+		err := cache.SetGitReferences("test-repo", *GitRefCacheItemToReferences([][2]string{{"test-repo", "ref: test"}}))
+		assert.NoError(t, err)
+		cache.revisionCacheLockTimeout = -1 * time.Second
+		var references []*plumbing.Reference
+		updateCache, lockId, err := cache.GetOrLockGitReferences("test-repo", &references)
+		assert.NoError(t, err)
+		assert.True(t, updateCache)
+		assert.NotEqual(t, "", lockId, "Lock id should be set")
+		cache.revisionCacheLockTimeout = 10 * time.Second
+		fixtures.mockCache.AssertCacheCalledTimes(t, &mocks.CacheCallCounts{ExternalSets: 1})
+	})
+
+	t.Run("Test cache lock error", func(t *testing.T) {
+		fixtures := newFixtures()
+		t.Cleanup(fixtures.mockCache.StopRedisCallback)
+		cache := fixtures.cache
+		fixtures.cache.revisionCacheLockTimeout = 10 * time.Second
+		fixtures.mockCache.RedisClient.On("Set", mock.Anything).Unset()
+		fixtures.mockCache.RedisClient.On("Set", mock.Anything).Return(errors.New("test cache error")).Once().
+			On("Set", mock.Anything).Return(nil)
+		var references []*plumbing.Reference
+		updateCache, lockId, err := cache.GetOrLockGitReferences("test-repo", &references)
+		assert.NoError(t, err)
+		assert.True(t, updateCache)
+		assert.NotEqual(t, "", lockId, "Lock id should be set")
+		fixtures.mockCache.RedisClient.AssertNumberOfCalls(t, "Set", 2)
+		fixtures.mockCache.RedisClient.AssertNumberOfCalls(t, "Get", 4)
+	})
+}
+
+func TestUnlockGitReferences(t *testing.T) {
+	fixtures := newFixtures()
+	t.Cleanup(fixtures.mockCache.StopRedisCallback)
+	cache := fixtures.cache
+
+	t.Run("Test not locked", func(t *testing.T) {
+		err := cache.UnlockGitReferences("test-repo", "")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "key is missing")
+	})
+
+	t.Run("Test unlock", func(t *testing.T) {
+		// Get lock
+		var references []*plumbing.Reference
+		updateCache, lockId, err := cache.GetOrLockGitReferences("test-repo", &references)
+		assert.NoError(t, err)
+		assert.True(t, updateCache)
+		assert.NotEqual(t, "", lockId, "Lock id should be set")
+		// Release lock
+		err = cache.UnlockGitReferences("test-repo", lockId)
+		assert.NoError(t, err)
+	})
+}
+
+func TestSetHelmIndex(t *testing.T) {
+	t.Run("SetHelmIndex with valid data", func(t *testing.T) {
+		fixtures := newFixtures()
+		t.Cleanup(fixtures.mockCache.StopRedisCallback)
+		err := fixtures.cache.SetHelmIndex("test-repo", []byte("test-data"))
+		assert.NoError(t, err)
+		fixtures.mockCache.AssertCacheCalledTimes(t, &mocks.CacheCallCounts{ExternalSets: 1})
+	})
+	t.Run("SetHelmIndex with nil", func(t *testing.T) {
+		fixtures := newFixtures()
+		t.Cleanup(fixtures.mockCache.StopRedisCallback)
+		err := fixtures.cache.SetHelmIndex("test-repo", nil)
+		assert.Error(t, err, "nil data should not be cached")
+		var indexData []byte
+		err = fixtures.cache.GetHelmIndex("test-repo", &indexData)
+		assert.Error(t, err)
+		fixtures.mockCache.AssertCacheCalledTimes(t, &mocks.CacheCallCounts{ExternalGets: 1})
+	})
+}
+
+func TestRevisionChartDetails(t *testing.T) {
+	t.Run("GetRevisionChartDetails cache miss", func(t *testing.T) {
+		fixtures := newFixtures()
+		t.Cleanup(fixtures.mockCache.StopRedisCallback)
+		details, err := fixtures.cache.GetRevisionChartDetails("test-repo", "test-revision", "v1.0.0")
+		assert.ErrorAs(t, err, &ErrCacheMiss)
+		assert.Equal(t, &appv1.ChartDetails{}, details)
+		fixtures.mockCache.AssertCacheCalledTimes(t, &mocks.CacheCallCounts{ExternalGets: 1})
+	})
+	t.Run("GetRevisionChartDetails cache miss local", func(t *testing.T) {
+		fixtures := newFixtures()
+		t.Cleanup(fixtures.mockCache.StopRedisCallback)
+		cache := fixtures.cache
+		expectedItem := &appv1.ChartDetails{
+			Description: "test-chart",
+			Home:        "v1.0.0",
+			Maintainers: []string{"test-maintainer"},
+		}
+		err := cache.cache.SetItem(
+			revisionChartDetailsKey("test-repo", "test-revision", "v1.0.0"),
+			expectedItem,
+			&cacheutil.CacheActionOpts{Expiration: 30 * time.Second})
+		assert.NoError(t, err)
+		details, err := fixtures.cache.GetRevisionChartDetails("test-repo", "test-revision", "v1.0.0")
+		assert.NoError(t, err)
+		assert.Equal(t, expectedItem, details)
+		fixtures.mockCache.AssertCacheCalledTimes(t, &mocks.CacheCallCounts{ExternalGets: 1, ExternalSets: 1})
+	})
+
+	t.Run("GetRevisionChartDetails cache hit local", func(t *testing.T) {
+		fixtures := newFixtures()
+		t.Cleanup(fixtures.mockCache.StopRedisCallback)
+		cache := fixtures.cache
+		expectedItem := &appv1.ChartDetails{
+			Description: "test-chart",
+			Home:        "v1.0.0",
+			Maintainers: []string{"test-maintainer"},
+		}
+		err := cache.cache.SetItem(
+			revisionChartDetailsKey("test-repo", "test-revision", "v1.0.0"),
+			expectedItem,
+			&cacheutil.CacheActionOpts{Expiration: 30 * time.Second})
+		assert.NoError(t, err)
+		details, err := fixtures.cache.GetRevisionChartDetails("test-repo", "test-revision", "v1.0.0")
+		assert.NoError(t, err)
+		assert.Equal(t, expectedItem, details)
+		fixtures.mockCache.AssertCacheCalledTimes(t, &mocks.CacheCallCounts{ExternalGets: 1, ExternalSets: 1})
+	})
+
+	t.Run("SetRevisionChartDetails", func(t *testing.T) {
+		fixtures := newFixtures()
+		t.Cleanup(fixtures.mockCache.StopRedisCallback)
+		expectedItem := &appv1.ChartDetails{
+			Description: "test-chart",
+			Home:        "v1.0.0",
+			Maintainers: []string{"test-maintainer"},
+		}
+		err := fixtures.cache.SetRevisionChartDetails("test-repo", "test-revision", "v1.0.0", expectedItem)
+		assert.NoError(t, err)
+		details, err := fixtures.cache.GetRevisionChartDetails("test-repo", "test-revision", "v1.0.0")
+		assert.NoError(t, err)
+		assert.Equal(t, expectedItem, details)
+		fixtures.mockCache.AssertCacheCalledTimes(t, &mocks.CacheCallCounts{ExternalGets: 1, ExternalSets: 1})
+	})
+
+}
+
+func TestGetGitDirectories(t *testing.T) {
+	t.Run("GetGitDirectories cache miss", func(t *testing.T) {
+		fixtures := newFixtures()
+		t.Cleanup(fixtures.mockCache.StopRedisCallback)
+		directories, err := fixtures.cache.GetGitDirectories("test-repo", "test-revision")
+		assert.ErrorAs(t, err, &ErrCacheMiss)
+		assert.Equal(t, 0, len(directories))
+		fixtures.mockCache.AssertCacheCalledTimes(t, &mocks.CacheCallCounts{ExternalGets: 1})
+	})
+	t.Run("GetGitDirectories cache miss local", func(t *testing.T) {
+		fixtures := newFixtures()
+		t.Cleanup(fixtures.mockCache.StopRedisCallback)
+		cache := fixtures.cache
+		expectedItem := []string{"test/dir", "test/dir2"}
+		err := cache.cache.SetItem(
+			gitDirectoriesKey("test-repo", "test-revision"),
+			expectedItem,
+			&cacheutil.CacheActionOpts{Expiration: 30 * time.Second})
+		assert.NoError(t, err)
+		directories, err := fixtures.cache.GetGitDirectories("test-repo", "test-revision")
+		assert.NoError(t, err)
+		assert.Equal(t, expectedItem, directories)
+		fixtures.mockCache.AssertCacheCalledTimes(t, &mocks.CacheCallCounts{ExternalGets: 1, ExternalSets: 1})
+	})
+
+	t.Run("GetGitDirectories cache hit local", func(t *testing.T) {
+		fixtures := newFixtures()
+		t.Cleanup(fixtures.mockCache.StopRedisCallback)
+		cache := fixtures.cache
+		expectedItem := []string{"test/dir", "test/dir2"}
+		err := cache.cache.SetItem(
+			gitDirectoriesKey("test-repo", "test-revision"),
+			expectedItem,
+			&cacheutil.CacheActionOpts{Expiration: 30 * time.Second})
+		assert.NoError(t, err)
+		directories, err := fixtures.cache.GetGitDirectories("test-repo", "test-revision")
+		assert.NoError(t, err)
+		assert.Equal(t, expectedItem, directories)
+		fixtures.mockCache.AssertCacheCalledTimes(t, &mocks.CacheCallCounts{ExternalGets: 1, ExternalSets: 1})
+	})
+
+	t.Run("SetGitDirectories", func(t *testing.T) {
+		fixtures := newFixtures()
+		t.Cleanup(fixtures.mockCache.StopRedisCallback)
+		expectedItem := []string{"test/dir", "test/dir2"}
+		err := fixtures.cache.SetGitDirectories("test-repo", "test-revision", expectedItem)
+		assert.NoError(t, err)
+		directories, err := fixtures.cache.GetGitDirectories("test-repo", "test-revision")
+		assert.NoError(t, err)
+		assert.Equal(t, expectedItem, directories)
+		fixtures.mockCache.AssertCacheCalledTimes(t, &mocks.CacheCallCounts{ExternalGets: 1, ExternalSets: 1})
+	})
+
+}
+
+func TestGetGitFiles(t *testing.T) {
+	t.Run("GetGitFiles cache miss", func(t *testing.T) {
+		fixtures := newFixtures()
+		t.Cleanup(fixtures.mockCache.StopRedisCallback)
+		directories, err := fixtures.cache.GetGitFiles("test-repo", "test-revision", "*.json")
+		assert.ErrorAs(t, err, &ErrCacheMiss)
+		assert.Equal(t, 0, len(directories))
+		fixtures.mockCache.AssertCacheCalledTimes(t, &mocks.CacheCallCounts{ExternalGets: 1})
+	})
+	t.Run("GetGitFiles cache hit", func(t *testing.T) {
+		fixtures := newFixtures()
+		t.Cleanup(fixtures.mockCache.StopRedisCallback)
+		cache := fixtures.cache
+		expectedItem := map[string][]byte{"test/file.json": []byte("\"test\":\"contents\""), "test/file1.json": []byte("\"test1\":\"contents1\"")}
+		err := cache.cache.SetItem(
+			gitFilesKey("test-repo", "test-revision", "*.json"),
+			expectedItem,
+			&cacheutil.CacheActionOpts{Expiration: 30 * time.Second})
+		assert.NoError(t, err)
+		files, err := fixtures.cache.GetGitFiles("test-repo", "test-revision", "*.json")
+		assert.NoError(t, err)
+		assert.Equal(t, expectedItem, files)
+		fixtures.mockCache.AssertCacheCalledTimes(t, &mocks.CacheCallCounts{ExternalGets: 1, ExternalSets: 1})
+	})
+
+	t.Run("SetGitFiles", func(t *testing.T) {
+		fixtures := newFixtures()
+		t.Cleanup(fixtures.mockCache.StopRedisCallback)
+		expectedItem := map[string][]byte{"test/file.json": []byte("\"test\":\"contents\""), "test/file1.json": []byte("\"test1\":\"contents1\"")}
+		err := fixtures.cache.SetGitFiles("test-repo", "test-revision", "*.json", expectedItem)
+		assert.NoError(t, err)
+		files, err := fixtures.cache.GetGitFiles("test-repo", "test-revision", "*.json")
+		assert.NoError(t, err)
+		assert.Equal(t, expectedItem, files)
+		fixtures.mockCache.AssertCacheCalledTimes(t, &mocks.CacheCallCounts{ExternalGets: 1, ExternalSets: 1})
+	})
 
 }

--- a/reposerver/cache/mocks/reposervercache.go
+++ b/reposerver/cache/mocks/reposervercache.go
@@ -1,0 +1,71 @@
+package mocks
+
+import (
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	cacheutil "github.com/argoproj/argo-cd/v2/util/cache"
+	cacheutilmocks "github.com/argoproj/argo-cd/v2/util/cache/mocks"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockCacheType int
+
+const (
+	MockCacheTypeRedis MockCacheType = iota
+	MockCacheTypeInMem
+)
+
+type MockRepoCache struct {
+	mock.Mock
+	RedisClient       *cacheutilmocks.MockCacheClient
+	StopRedisCallback func()
+}
+
+type MockCacheOptions struct {
+	RepoCacheExpiration     time.Duration
+	RevisionCacheExpiration time.Duration
+	ReadDelay               time.Duration
+	WriteDelay              time.Duration
+}
+
+type CacheCallCounts struct {
+	ExternalSets    int
+	ExternalGets    int
+	ExternalDeletes int
+}
+
+// Checks that the cache was called the expected number of times
+func (mockCache *MockRepoCache) AssertCacheCalledTimes(t *testing.T, calls *CacheCallCounts) {
+	mockCache.RedisClient.AssertNumberOfCalls(t, "Get", calls.ExternalGets)
+	mockCache.RedisClient.AssertNumberOfCalls(t, "Set", calls.ExternalSets)
+	mockCache.RedisClient.AssertNumberOfCalls(t, "Delete", calls.ExternalDeletes)
+}
+
+func (mockCache *MockRepoCache) ConfigureDefaultCallbacks() {
+	mockCache.RedisClient.On("Get", mock.Anything, mock.Anything).Return(nil)
+	mockCache.RedisClient.On("Set", mock.Anything).Return(nil)
+	mockCache.RedisClient.On("Delete", mock.Anything).Return(nil)
+}
+
+func NewInMemoryRedis() (*redis.Client, func()) {
+	cacheutil.NewInMemoryCache(5 * time.Second)
+	mr, err := miniredis.Run()
+	if err != nil {
+		panic(err)
+	}
+	return redis.NewClient(&redis.Options{Addr: mr.Addr()}), mr.Close
+}
+
+func NewMockRepoCache(cacheOpts *MockCacheOptions) *MockRepoCache {
+	redisClient, stopRedis := NewInMemoryRedis()
+	redisCacheClient := &cacheutilmocks.MockCacheClient{
+		ReadDelay:  cacheOpts.ReadDelay,
+		WriteDelay: cacheOpts.WriteDelay,
+		BaseCache:  cacheutil.NewRedisCache(redisClient, cacheOpts.RepoCacheExpiration, cacheutil.RedisCompressionNone)}
+	newMockCache := &MockRepoCache{RedisClient: redisCacheClient, StopRedisCallback: stopRedis}
+	newMockCache.ConfigureDefaultCallbacks()
+	return newMockCache
+}

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -337,6 +337,62 @@ func TestGenerateManifests_EmptyCache(t *testing.T) {
 	gitMocks.AssertCalled(t, "Fetch", mock.Anything)
 }
 
+// Test that when Generate manifest is called with a source that is ref only it does not try to generate manifests or hit the manifest cache
+// but it does resolve and cache the revision
+func TestGenerateManifest_RefOnlyShortCircuit(t *testing.T) {
+	lsremoteCalled := false
+	dir := t.TempDir()
+	repopath := fmt.Sprintf("%s/tmprepo", dir)
+	repoRemote := fmt.Sprintf("file://%s", repopath)
+	cacheMocks := newCacheMocks()
+	t.Cleanup(cacheMocks.mockCache.StopRedisCallback)
+	service := NewService(metrics.NewMetricsServer(), cacheMocks.cache, RepoServerInitConstants{ParallelismLimit: 1}, argo.NewResourceTracking(), &git.NoopCredsStore{}, repopath)
+	service.newGitClient = func(rawRepoURL string, root string, creds git.Creds, insecure bool, enableLfs bool, proxy string, opts ...git.ClientOpts) (client git.Client, e error) {
+		opts = append(opts, git.WithEventHandlers(git.EventHandlers{
+			// Primary check, we want to make sure ls-remote is not called when the item is in cache
+			OnLsRemote: func(repo string) func() {
+				return func() {
+					lsremoteCalled = true
+				}
+			},
+			OnFetch: func(repo string) func() {
+				return func() {
+					assert.Fail(t, "Fetch should not be called from GenerateManifest when the source is ref only")
+				}
+			},
+		}))
+		gitClient, err := git.NewClientExt(rawRepoURL, root, creds, insecure, enableLfs, proxy, opts...)
+		return gitClient, err
+	}
+	revision := initGitRepo(t, newGitRepoOptions{
+		path:           repopath,
+		createPath:     true,
+		remote:         repoRemote,
+		addEmptyCommit: true,
+	})
+	src := argoappv1.ApplicationSource{RepoURL: repoRemote, TargetRevision: "HEAD", Ref: "test-ref"}
+	repo := &argoappv1.Repository{
+		Repo: repoRemote,
+	}
+	q := apiclient.ManifestRequest{
+		Repo:               repo,
+		Revision:           "HEAD",
+		HasMultipleSources: true,
+		ApplicationSource:  &src,
+		ProjectName:        "default",
+		ProjectSourceRepos: []string{"*"},
+	}
+	_, err := service.GenerateManifest(context.Background(), &q)
+	assert.NoError(t, err)
+	cacheMocks.mockCache.AssertCacheCalledTimes(t, &repositorymocks.CacheCallCounts{
+		ExternalSets: 1,
+		ExternalGets: 1})
+	assert.True(t, lsremoteCalled, "ls-remote should be called when the source is ref only")
+	var revisions [][2]string
+	assert.NoError(t, cacheMocks.cacheutilCache.GetItem(fmt.Sprintf("git-refs|%s", repoRemote), &revisions))
+	assert.Equal(t, [][2]string{{"refs/heads/main", revision}, {"HEAD", "ref: refs/heads/main"}}, revisions)
+}
+
 // Test that calling manifest generation on source helm reference helm files that when the revision is cached it does not call ls-remote
 func TestGenerateManifestsHelmWithRefs_CachedNoLsRemote(t *testing.T) {
 	dir := t.TempDir()

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -15,6 +15,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -30,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/yaml"
 
+	"github.com/argoproj/argo-cd/v2/common"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	argoappv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/reposerver/apiclient"
@@ -385,11 +387,11 @@ func TestGenerateManifest_RefOnlyShortCircuit(t *testing.T) {
 	_, err := service.GenerateManifest(context.Background(), &q)
 	assert.NoError(t, err)
 	cacheMocks.mockCache.AssertCacheCalledTimes(t, &repositorymocks.CacheCallCounts{
-		ExternalSets: 1,
-		ExternalGets: 1})
+		ExternalSets: 2,
+		ExternalGets: 2})
 	assert.True(t, lsremoteCalled, "ls-remote should be called when the source is ref only")
 	var revisions [][2]string
-	assert.NoError(t, cacheMocks.cacheutilCache.GetItem(fmt.Sprintf("git-refs|%s", repoRemote), &revisions))
+	assert.NoError(t, cacheMocks.cacheutilCache.GetItem(fmt.Sprintf("git-refs|%s", repoRemote), &revisions, nil))
 	assert.Equal(t, [][2]string{{"refs/heads/main", revision}, {"HEAD", "ref: refs/heads/main"}}, revisions)
 }
 
@@ -451,7 +453,7 @@ func TestGenerateManifestsHelmWithRefs_CachedNoLsRemote(t *testing.T) {
 		ProjectSourceRepos: []string{"*"},
 		RefSources:         map[string]*argoappv1.RefTarget{"$ref": {TargetRevision: "HEAD", Repo: *repo}},
 	}
-	err = cacheMocks.cacheutilCache.SetItem(fmt.Sprintf("git-refs|%s", repoRemote), [][2]string{{"HEAD", revision}}, 30*time.Second, false)
+	err = cacheMocks.cacheutilCache.SetItem(fmt.Sprintf("git-refs|%s", repoRemote), [][2]string{{"HEAD", revision}}, nil)
 	assert.NoError(t, err)
 	_, err = service.GenerateManifest(context.Background(), &q)
 	assert.NoError(t, err)
@@ -3346,6 +3348,113 @@ func Test_getRepoSanitizerRegex(t *testing.T) {
 	assert.Equal(t, "error message containing <path to cached source> and other stuff", msg)
 	msg = r.ReplaceAllString("error message containing /tmp/_argocd-repo/SENSITIVE/with/trailing/path and other stuff", "<path to cached source>")
 	assert.Equal(t, "error message containing <path to cached source>/with/trailing/path and other stuff", msg)
+}
+
+func TestGetRefs_CacheDisabled(t *testing.T) {
+	// Test that default get refs with cache disabled does not call GetOrLockGitReferences
+	dir := t.TempDir()
+	initGitRepo(t, newGitRepoOptions{
+		path:           dir,
+		createPath:     false,
+		remote:         "",
+		addEmptyCommit: true,
+	})
+	cacheMocks := newCacheMocks()
+	t.Cleanup(cacheMocks.mockCache.StopRedisCallback)
+	client, err := git.NewClient(fmt.Sprintf("file://%s", dir), git.NopCreds{}, true, false, "", git.WithCache(cacheMocks.cache, false))
+	require.NoError(t, err)
+	refs, err := client.LsRefs()
+	assert.NoError(t, err)
+	assert.NotNil(t, refs)
+	assert.NotEqual(t, 0, len(refs.Branches), "Expected branches to be populated")
+	assert.NotEmpty(t, refs.Branches[0])
+	// Unlock should not have been called
+	cacheMocks.mockCache.AssertNumberOfCalls(t, "UnlockGitReferences", 0)
+	cacheMocks.mockCache.AssertNumberOfCalls(t, "GetOrLockGitReferences", 0)
+}
+
+func TestGetRefs_CacheWithLock(t *testing.T) {
+	// Test that there is only one call to SetGitReferences for the same repo which is done after the ls-remote
+	dir := t.TempDir()
+	initGitRepo(t, newGitRepoOptions{
+		path:           dir,
+		createPath:     false,
+		remote:         "",
+		addEmptyCommit: true,
+	})
+	cacheMocks := newCacheMocks()
+	t.Cleanup(cacheMocks.mockCache.StopRedisCallback)
+	var wg sync.WaitGroup
+	numberOfCallers := 10
+	for i := 0; i < numberOfCallers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			client, err := git.NewClient(fmt.Sprintf("file://%s", dir), git.NopCreds{}, true, false, "", git.WithCache(cacheMocks.cache, true))
+			require.NoError(t, err)
+			refs, err := client.LsRefs()
+			assert.NoError(t, err)
+			assert.NotNil(t, refs)
+			assert.NotEqual(t, 0, len(refs.Branches), "Expected branches to be populated")
+			assert.NotEmpty(t, refs.Branches[0])
+		}()
+	}
+	wg.Wait()
+	// Unlock should not have been called
+	cacheMocks.mockCache.AssertNumberOfCalls(t, "UnlockGitReferences", 0)
+	cacheMocks.mockCache.AssertNumberOfCalls(t, "GetOrLockGitReferences", 0)
+}
+
+func TestGetRefs_CacheUnlockedOnUpdateFailed(t *testing.T) {
+	// Worst case the ttl on the lock expires and the lock is removed
+	// however if the holder of the lock fails to update the cache the caller should remove the lock
+	// to allow other callers to attempt to update the cache as quickly as possible
+	dir := t.TempDir()
+	initGitRepo(t, newGitRepoOptions{
+		path:           dir,
+		createPath:     false,
+		remote:         "",
+		addEmptyCommit: true,
+	})
+	cacheMocks := newCacheMocks()
+	t.Cleanup(cacheMocks.mockCache.StopRedisCallback)
+	repoUrl := fmt.Sprintf("file://%s", dir)
+	client, err := git.NewClient(repoUrl, git.NopCreds{}, true, false, "", git.WithCache(cacheMocks.cache, true))
+	require.NoError(t, err)
+	refs, err := client.LsRefs()
+	assert.NoError(t, err)
+	assert.NotNil(t, refs)
+	assert.NotEqual(t, 0, len(refs.Branches), "Expected branches to be populated")
+	assert.NotEmpty(t, refs.Branches[0])
+	var output [][2]string
+	err = cacheMocks.cacheutilCache.GetItem(fmt.Sprintf("git-refs|%s|%s", repoUrl, common.CacheVersion), &output, nil)
+	assert.Error(t, err, "Should be a cache miss")
+	assert.Equal(t, 0, len(output), "Expected cache to be empty for key")
+	cacheMocks.mockCache.AssertNumberOfCalls(t, "UnlockGitReferences", 0)
+	cacheMocks.mockCache.AssertNumberOfCalls(t, "GetOrLockGitReferences", 0)
+}
+
+func TestGetRefs_CacheLockTryLockGitRefCacheError(t *testing.T) {
+	// Worst case the ttl on the lock expires and the lock is removed
+	// however if the holder of the lock fails to update the cache the caller should remove the lock
+	// to allow other callers to attempt to update the cache as quickly as possible
+	dir := t.TempDir()
+	initGitRepo(t, newGitRepoOptions{
+		path:           dir,
+		createPath:     false,
+		remote:         "",
+		addEmptyCommit: true,
+	})
+	cacheMocks := newCacheMocks()
+	t.Cleanup(cacheMocks.mockCache.StopRedisCallback)
+	repoUrl := fmt.Sprintf("file://%s", dir)
+	// buf := bytes.Buffer{}
+	// log.SetOutput(&buf)
+	client, err := git.NewClient(repoUrl, git.NopCreds{}, true, false, "", git.WithCache(cacheMocks.cache, true))
+	require.NoError(t, err)
+	refs, err := client.LsRefs()
+	assert.NoError(t, err)
+	assert.NotNil(t, refs)
 }
 
 func TestGetRevisionChartDetails(t *testing.T) {

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -17,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	cacheutil "github.com/argoproj/argo-cd/v2/util/cache"
 	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/resource"
 
@@ -28,13 +30,14 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/yaml"
 
+	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	argoappv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/reposerver/apiclient"
 	"github.com/argoproj/argo-cd/v2/reposerver/cache"
+	repositorymocks "github.com/argoproj/argo-cd/v2/reposerver/cache/mocks"
 	"github.com/argoproj/argo-cd/v2/reposerver/metrics"
 	fileutil "github.com/argoproj/argo-cd/v2/test/fixture/path"
 	"github.com/argoproj/argo-cd/v2/util/argo"
-	cacheutil "github.com/argoproj/argo-cd/v2/util/cache"
 	dbmocks "github.com/argoproj/argo-cd/v2/util/db/mocks"
 	"github.com/argoproj/argo-cd/v2/util/git"
 	gitmocks "github.com/argoproj/argo-cd/v2/util/git/mocks"
@@ -51,12 +54,49 @@ gpg: Good signature from "GitHub (web-flow commit signing) <noreply@github.com>"
 
 type clientFunc func(*gitmocks.Client, *helmmocks.Client, *iomocks.TempPaths)
 
-func newServiceWithMocks(root string, signed bool) (*Service, *gitmocks.Client) {
+type repoCacheMocks struct {
+	mock.Mock
+	cacheutilCache *cacheutil.Cache
+	cache          *cache.Cache
+	mockCache      *repositorymocks.MockRepoCache
+}
+
+type newGitRepoHelmChartOptions struct {
+	chartName    string
+	chartVersion string
+	// valuesFiles is a map of the values file name to the key/value pairs to be written to the file
+	valuesFiles map[string]map[string]string
+}
+
+type newGitRepoOptions struct {
+	path             string
+	createPath       bool
+	remote           string
+	addEmptyCommit   bool
+	helmChartOptions newGitRepoHelmChartOptions
+}
+
+func newCacheMocks() *repoCacheMocks {
+	mockRepoCache := repositorymocks.NewMockRepoCache(&repositorymocks.MockCacheOptions{
+		RepoCacheExpiration:     1 * time.Minute,
+		RevisionCacheExpiration: 1 * time.Minute,
+		ReadDelay:               0,
+		WriteDelay:              0,
+	})
+	cacheutilCache := cacheutil.NewCache(mockRepoCache.RedisClient)
+	return &repoCacheMocks{
+		cacheutilCache: cacheutilCache,
+		cache:          cache.NewCache(cacheutilCache, 1*time.Minute, 1*time.Minute),
+		mockCache:      mockRepoCache,
+	}
+}
+
+func newServiceWithMocks(t *testing.T, root string, signed bool) (*Service, *gitmocks.Client, *repoCacheMocks) {
 	root, err := filepath.Abs(root)
 	if err != nil {
 		panic(err)
 	}
-	return newServiceWithOpt(func(gitClient *gitmocks.Client, helmClient *helmmocks.Client, paths *iomocks.TempPaths) {
+	return newServiceWithOpt(t, func(gitClient *gitmocks.Client, helmClient *helmmocks.Client, paths *iomocks.TempPaths) {
 		gitClient.On("Init").Return(nil)
 		gitClient.On("Fetch", mock.Anything).Return(nil)
 		gitClient.On("Checkout", mock.Anything, mock.Anything).Return(nil)
@@ -73,7 +113,7 @@ func newServiceWithMocks(root string, signed bool) (*Service, *gitmocks.Client) 
 		chart := "my-chart"
 		oobChart := "out-of-bounds-chart"
 		version := "1.1.0"
-		helmClient.On("GetIndex", true).Return(&helm.Index{Entries: map[string]helm.Entries{
+		helmClient.On("GetIndex", mock.AnythingOfType("bool")).Return(&helm.Index{Entries: map[string]helm.Entries{
 			chart:    {{Version: "1.0.0"}, {Version: version}},
 			oobChart: {{Version: "1.0.0"}, {Version: version}},
 		}}, nil)
@@ -89,18 +129,16 @@ func newServiceWithMocks(root string, signed bool) (*Service, *gitmocks.Client) 
 	}, root)
 }
 
-func newServiceWithOpt(cf clientFunc, root string) (*Service, *gitmocks.Client) {
+func newServiceWithOpt(t *testing.T, cf clientFunc, root string) (*Service, *gitmocks.Client, *repoCacheMocks) {
 	helmClient := &helmmocks.Client{}
 	gitClient := &gitmocks.Client{}
 	paths := &iomocks.TempPaths{}
 	cf(gitClient, helmClient, paths)
-	service := NewService(metrics.NewMetricsServer(), cache.NewCache(
-		cacheutil.NewCache(cacheutil.NewInMemoryCache(1*time.Minute)),
-		1*time.Minute,
-		1*time.Minute,
-	), RepoServerInitConstants{ParallelismLimit: 1}, argo.NewResourceTracking(), &git.NoopCredsStore{}, root)
+	cacheMocks := newCacheMocks()
+	t.Cleanup(cacheMocks.mockCache.StopRedisCallback)
+	service := NewService(metrics.NewMetricsServer(), cacheMocks.cache, RepoServerInitConstants{ParallelismLimit: 1}, argo.NewResourceTracking(), &git.NoopCredsStore{}, root)
 
-	service.newGitClient = func(rawRepoURL string, root string, creds git.Creds, insecure bool, enableLfs bool, prosy string, opts ...git.ClientOpts) (client git.Client, e error) {
+	service.newGitClient = func(rawRepoURL string, root string, creds git.Creds, insecure bool, enableLfs bool, proxy string, opts ...git.ClientOpts) (client git.Client, e error) {
 		return gitClient, nil
 	}
 	service.newHelmClient = func(repoURL string, creds helm.Creds, enableOci bool, proxy string, opts ...helm.ClientOpts) helm.Client {
@@ -110,20 +148,20 @@ func newServiceWithOpt(cf clientFunc, root string) (*Service, *gitmocks.Client) 
 		return io.NopCloser
 	}
 	service.gitRepoPaths = paths
-	return service, gitClient
+	return service, gitClient, cacheMocks
 }
 
-func newService(root string) *Service {
-	service, _ := newServiceWithMocks(root, false)
+func newService(t *testing.T, root string) *Service {
+	service, _, _ := newServiceWithMocks(t, root, false)
 	return service
 }
 
-func newServiceWithSignature(root string) *Service {
-	service, _ := newServiceWithMocks(root, true)
+func newServiceWithSignature(t *testing.T, root string) *Service {
+	service, _, _ := newServiceWithMocks(t, root, true)
 	return service
 }
 
-func newServiceWithCommitSHA(root, revision string) *Service {
+func newServiceWithCommitSHA(t *testing.T, root, revision string) *Service {
 	var revisionErr error
 
 	commitSHARegex := regexp.MustCompile("^[0-9A-Fa-f]{40}$")
@@ -131,7 +169,7 @@ func newServiceWithCommitSHA(root, revision string) *Service {
 		revisionErr = errors.New("not a commit SHA")
 	}
 
-	service, gitClient := newServiceWithOpt(func(gitClient *gitmocks.Client, helmClient *helmmocks.Client, paths *iomocks.TempPaths) {
+	service, gitClient, _ := newServiceWithOpt(t, func(gitClient *gitmocks.Client, helmClient *helmmocks.Client, paths *iomocks.TempPaths) {
 		gitClient.On("Init").Return(nil)
 		gitClient.On("Fetch", mock.Anything).Return(nil)
 		gitClient.On("Checkout", mock.Anything, mock.Anything).Return(nil)
@@ -150,7 +188,7 @@ func newServiceWithCommitSHA(root, revision string) *Service {
 }
 
 func TestGenerateYamlManifestInDir(t *testing.T) {
-	service := newService("../../manifests/base")
+	service := newService(t, "../../manifests/base")
 
 	src := argoappv1.ApplicationSource{Path: "."}
 	q := apiclient.ManifestRequest{
@@ -247,7 +285,7 @@ func TestGenerateManifests_MissingSymlinkDestination(t *testing.T) {
 }
 
 func TestGenerateManifests_K8SAPIResetCache(t *testing.T) {
-	service := newService("../../manifests/base")
+	service := newService(t, "../../manifests/base")
 
 	src := argoappv1.ApplicationSource{Path: "."}
 	q := apiclient.ManifestRequest{
@@ -275,7 +313,7 @@ func TestGenerateManifests_K8SAPIResetCache(t *testing.T) {
 }
 
 func TestGenerateManifests_EmptyCache(t *testing.T) {
-	service := newService("../../manifests/base")
+	service, gitMocks, mockCache := newServiceWithMocks(t, "../../manifests/base", false)
 
 	src := argoappv1.ApplicationSource{Path: "."}
 	q := apiclient.ManifestRequest{
@@ -291,11 +329,85 @@ func TestGenerateManifests_EmptyCache(t *testing.T) {
 	res, err := service.GenerateManifest(context.Background(), &q)
 	assert.NoError(t, err)
 	assert.True(t, len(res.Manifests) > 0)
+	mockCache.mockCache.AssertCacheCalledTimes(t, &repositorymocks.CacheCallCounts{
+		ExternalSets:    2,
+		ExternalGets:    2,
+		ExternalDeletes: 1})
+	gitMocks.AssertCalled(t, "LsRemote", mock.Anything)
+	gitMocks.AssertCalled(t, "Fetch", mock.Anything)
+}
+
+// Test that calling manifest generation on source helm reference helm files that when the revision is cached it does not call ls-remote
+func TestGenerateManifestsHelmWithRefs_CachedNoLsRemote(t *testing.T) {
+	dir := t.TempDir()
+	repopath := fmt.Sprintf("%s/tmprepo", dir)
+	cacheMocks := newCacheMocks()
+	t.Cleanup(func() {
+		cacheMocks.mockCache.StopRedisCallback()
+		err := filepath.WalkDir(dir,
+			func(path string, di fs.DirEntry, err error) error {
+				if err == nil {
+					return os.Chmod(path, 0777)
+				}
+				return err
+			})
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+	service := NewService(metrics.NewMetricsServer(), cacheMocks.cache, RepoServerInitConstants{ParallelismLimit: 1}, argo.NewResourceTracking(), &git.NoopCredsStore{}, repopath)
+	var gitClient git.Client
+	var err error
+	service.newGitClient = func(rawRepoURL string, root string, creds git.Creds, insecure bool, enableLfs bool, proxy string, opts ...git.ClientOpts) (client git.Client, e error) {
+		opts = append(opts, git.WithEventHandlers(git.EventHandlers{
+			// Primary check, we want to make sure ls-remote is not called when the item is in cache
+			OnLsRemote: func(repo string) func() {
+				return func() {
+					assert.Fail(t, "LsRemote should not be called when the item is in cache")
+				}
+			},
+		}))
+		gitClient, err = git.NewClientExt(rawRepoURL, root, creds, insecure, enableLfs, proxy, opts...)
+		return gitClient, err
+	}
+	repoRemote := fmt.Sprintf("file://%s", repopath)
+	revision := initGitRepo(t, newGitRepoOptions{
+		path:       repopath,
+		createPath: true,
+		remote:     repoRemote,
+		helmChartOptions: newGitRepoHelmChartOptions{
+			chartName:    "my-chart",
+			chartVersion: "v1.0.0",
+			valuesFiles:  map[string]map[string]string{"test.yaml": {"testval": "test"}}},
+	})
+	src := argoappv1.ApplicationSource{RepoURL: repoRemote, Path: ".", TargetRevision: "HEAD", Helm: &argoappv1.ApplicationSourceHelm{
+		ValueFiles: []string{"$ref/test.yaml"},
+	}}
+	repo := &argoappv1.Repository{
+		Repo: repoRemote,
+	}
+	q := apiclient.ManifestRequest{
+		Repo:               repo,
+		Revision:           "HEAD",
+		HasMultipleSources: true,
+		ApplicationSource:  &src,
+		ProjectName:        "default",
+		ProjectSourceRepos: []string{"*"},
+		RefSources:         map[string]*argoappv1.RefTarget{"$ref": {TargetRevision: "HEAD", Repo: *repo}},
+	}
+	err = cacheMocks.cacheutilCache.SetItem(fmt.Sprintf("git-refs|%s", repoRemote), [][2]string{{"HEAD", revision}}, 30*time.Second, false)
+	assert.NoError(t, err)
+	_, err = service.GenerateManifest(context.Background(), &q)
+	assert.NoError(t, err)
+	cacheMocks.mockCache.AssertCacheCalledTimes(t, &repositorymocks.CacheCallCounts{
+		ExternalSets: 2,
+		ExternalGets: 5})
 }
 
 // ensure we can use a semver constraint range (>= 1.0.0) and get back the correct chart (1.0.0)
 func TestHelmManifestFromChartRepo(t *testing.T) {
-	service := newService(".")
+	root := t.TempDir()
+	service, gitMocks, mockCache := newServiceWithMocks(t, root, false)
 	source := &argoappv1.ApplicationSource{Chart: "my-chart", TargetRevision: ">= 1.0.0"}
 	request := &apiclient.ManifestRequest{Repo: &argoappv1.Repository{}, ApplicationSource: source, NoCache: true, ProjectName: "something",
 		ProjectSourceRepos: []string{"*"}}
@@ -309,10 +421,14 @@ func TestHelmManifestFromChartRepo(t *testing.T) {
 		Revision:   "1.1.0",
 		SourceType: "Helm",
 	}, response)
+	mockCache.mockCache.AssertCacheCalledTimes(t, &repositorymocks.CacheCallCounts{
+		ExternalSets: 1,
+		ExternalGets: 0})
+	gitMocks.AssertNotCalled(t, "LsRemote", mock.Anything)
 }
 
 func TestHelmChartReferencingExternalValues(t *testing.T) {
-	service := newService(".")
+	service := newService(t, ".")
 	spec := argoappv1.ApplicationSpec{
 		Sources: []argoappv1.ApplicationSource{
 			{RepoURL: "https://helm.example.com", Chart: "my-chart", TargetRevision: ">= 1.0.0", Helm: &argoappv1.ApplicationSourceHelm{
@@ -342,7 +458,7 @@ func TestHelmChartReferencingExternalValues(t *testing.T) {
 }
 
 func TestHelmChartReferencingExternalValues_OutOfBounds_Symlink(t *testing.T) {
-	service := newService(".")
+	service := newService(t, ".")
 	err := os.Mkdir("testdata/oob-symlink", 0755)
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -376,7 +492,7 @@ func TestHelmChartReferencingExternalValues_OutOfBounds_Symlink(t *testing.T) {
 }
 
 func TestGenerateManifestsUseExactRevision(t *testing.T) {
-	service, gitClient := newServiceWithMocks(".", false)
+	service, gitClient, _ := newServiceWithMocks(t, ".", false)
 
 	src := argoappv1.ApplicationSource{Path: "./testdata/recurse", Directory: &argoappv1.ApplicationSourceDirectory{Recurse: true}}
 
@@ -390,7 +506,7 @@ func TestGenerateManifestsUseExactRevision(t *testing.T) {
 }
 
 func TestRecurseManifestsInDir(t *testing.T) {
-	service := newService(".")
+	service := newService(t, ".")
 
 	src := argoappv1.ApplicationSource{Path: "./testdata/recurse", Directory: &argoappv1.ApplicationSourceDirectory{Recurse: true}}
 
@@ -403,7 +519,7 @@ func TestRecurseManifestsInDir(t *testing.T) {
 }
 
 func TestInvalidManifestsInDir(t *testing.T) {
-	service := newService(".")
+	service := newService(t, ".")
 
 	src := argoappv1.ApplicationSource{Path: "./testdata/invalid-manifests", Directory: &argoappv1.ApplicationSourceDirectory{Recurse: true}}
 
@@ -414,7 +530,7 @@ func TestInvalidManifestsInDir(t *testing.T) {
 }
 
 func TestInvalidMetadata(t *testing.T) {
-	service := newService(".")
+	service := newService(t, ".")
 
 	src := argoappv1.ApplicationSource{Path: "./testdata/invalid-metadata", Directory: &argoappv1.ApplicationSourceDirectory{Recurse: true}}
 	q := apiclient.ManifestRequest{Repo: &argoappv1.Repository{}, ApplicationSource: &src, AppLabelKey: "test", AppName: "invalid-metadata", TrackingMethod: "annotation+label"}
@@ -424,7 +540,7 @@ func TestInvalidMetadata(t *testing.T) {
 }
 
 func TestNilMetadataAccessors(t *testing.T) {
-	service := newService(".")
+	service := newService(t, ".")
 	expected := "{\"apiVersion\":\"v1\",\"kind\":\"ConfigMap\",\"metadata\":{\"annotations\":{\"argocd.argoproj.io/tracking-id\":\"nil-metadata-accessors:/ConfigMap:/my-map\"},\"labels\":{\"test\":\"nil-metadata-accessors\"},\"name\":\"my-map\"},\"stringData\":{\"foo\":\"bar\"}}"
 
 	src := argoappv1.ApplicationSource{Path: "./testdata/nil-metadata-accessors", Directory: &argoappv1.ApplicationSourceDirectory{Recurse: true}}
@@ -436,7 +552,7 @@ func TestNilMetadataAccessors(t *testing.T) {
 }
 
 func TestGenerateJsonnetManifestInDir(t *testing.T) {
-	service := newService(".")
+	service := newService(t, ".")
 
 	q := apiclient.ManifestRequest{
 		Repo: &argoappv1.Repository{},
@@ -459,7 +575,7 @@ func TestGenerateJsonnetManifestInDir(t *testing.T) {
 }
 
 func TestGenerateJsonnetManifestInRootDir(t *testing.T) {
-	service := newService("testdata/jsonnet-1")
+	service := newService(t, "testdata/jsonnet-1")
 
 	q := apiclient.ManifestRequest{
 		Repo: &argoappv1.Repository{},
@@ -482,7 +598,7 @@ func TestGenerateJsonnetManifestInRootDir(t *testing.T) {
 }
 
 func TestGenerateJsonnetLibOutside(t *testing.T) {
-	service := newService(".")
+	service := newService(t, ".")
 
 	q := apiclient.ManifestRequest{
 		Repo: &argoappv1.Repository{},
@@ -553,7 +669,7 @@ func TestManifestGenErrorCacheByNumRequests(t *testing.T) {
 	for _, tt := range tests {
 		testName := fmt.Sprintf("gen-attempts-%d-pause-%d-total-%d", tt.PauseGenerationAfterFailedGenerationAttempts, tt.PauseGenerationOnFailureForRequests, tt.TotalCacheInvocations)
 		t.Run(testName, func(t *testing.T) {
-			service := newService(".")
+			service := newService(t, ".")
 
 			service.initConstants = RepoServerInitConstants{
 				ParallelismLimit: 1,
@@ -631,7 +747,7 @@ func TestManifestGenErrorCacheFileContentsChange(t *testing.T) {
 
 	tmpDir := t.TempDir()
 
-	service := newService(tmpDir)
+	service := newService(t, tmpDir)
 
 	service.initConstants = RepoServerInitConstants{
 		ParallelismLimit: 1,
@@ -701,7 +817,7 @@ func TestManifestGenErrorCacheByMinutesElapsed(t *testing.T) {
 	for _, tt := range tests {
 		testName := fmt.Sprintf("pause-time-%d", tt.PauseGenerationOnFailureForMinutes)
 		t.Run(testName, func(t *testing.T) {
-			service := newService(".")
+			service := newService(t, ".")
 
 			// Here we simulate the passage of time by overriding the now() function of Service
 			currentTime := time.Now()
@@ -771,7 +887,7 @@ func TestManifestGenErrorCacheByMinutesElapsed(t *testing.T) {
 
 func TestManifestGenErrorCacheRespectsNoCache(t *testing.T) {
 
-	service := newService(".")
+	service := newService(t, ".")
 
 	service.initConstants = RepoServerInitConstants{
 		ParallelismLimit: 1,
@@ -828,7 +944,7 @@ func TestManifestGenErrorCacheRespectsNoCache(t *testing.T) {
 }
 
 func TestGenerateHelmWithValues(t *testing.T) {
-	service := newService("../../util/helm/testdata/redis")
+	service := newService(t, "../../util/helm/testdata/redis")
 
 	res, err := service.GenerateManifest(context.Background(), &apiclient.ManifestRequest{
 		Repo:    &argoappv1.Repository{},
@@ -865,7 +981,7 @@ func TestGenerateHelmWithValues(t *testing.T) {
 }
 
 func TestHelmWithMissingValueFiles(t *testing.T) {
-	service := newService("../../util/helm/testdata/redis")
+	service := newService(t, "../../util/helm/testdata/redis")
 	missingValuesFile := "values-prod-overrides.yaml"
 
 	req := &apiclient.ManifestRequest{
@@ -893,7 +1009,7 @@ func TestHelmWithMissingValueFiles(t *testing.T) {
 }
 
 func TestGenerateHelmWithEnvVars(t *testing.T) {
-	service := newService("../../util/helm/testdata/redis")
+	service := newService(t, "../../util/helm/testdata/redis")
 
 	res, err := service.GenerateManifest(context.Background(), &apiclient.ManifestRequest{
 		Repo:    &argoappv1.Repository{},
@@ -930,7 +1046,7 @@ func TestGenerateHelmWithEnvVars(t *testing.T) {
 // The requested value file (`../minio/values.yaml`) is outside the app path (`./util/helm/testdata/redis`), however
 // since the requested value is still under the repo directory (`~/go/src/github.com/argoproj/argo-cd`), it is allowed
 func TestGenerateHelmWithValuesDirectoryTraversal(t *testing.T) {
-	service := newService("../../util/helm/testdata")
+	service := newService(t, "../../util/helm/testdata")
 	_, err := service.GenerateManifest(context.Background(), &apiclient.ManifestRequest{
 		Repo:    &argoappv1.Repository{},
 		AppName: "test",
@@ -947,7 +1063,7 @@ func TestGenerateHelmWithValuesDirectoryTraversal(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Test the case where the path is "."
-	service = newService("./testdata")
+	service = newService(t, "./testdata")
 	_, err = service.GenerateManifest(context.Background(), &apiclient.ManifestRequest{
 		Repo:    &argoappv1.Repository{},
 		AppName: "test",
@@ -961,7 +1077,7 @@ func TestGenerateHelmWithValuesDirectoryTraversal(t *testing.T) {
 }
 
 func TestChartRepoWithOutOfBoundsSymlink(t *testing.T) {
-	service := newService(".")
+	service := newService(t, ".")
 	source := &argoappv1.ApplicationSource{Chart: "out-of-bounds-chart", TargetRevision: ">= 1.0.0"}
 	request := &apiclient.ManifestRequest{Repo: &argoappv1.Repository{}, ApplicationSource: source, NoCache: true}
 	_, err := service.GenerateManifest(context.Background(), request)
@@ -971,7 +1087,7 @@ func TestChartRepoWithOutOfBoundsSymlink(t *testing.T) {
 // This is a Helm first-class app with a values file inside the repo directory
 // (`~/go/src/github.com/argoproj/argo-cd/reposerver/repository`), so it is allowed
 func TestHelmManifestFromChartRepoWithValueFile(t *testing.T) {
-	service := newService(".")
+	service := newService(t, ".")
 	source := &argoappv1.ApplicationSource{
 		Chart:          "my-chart",
 		TargetRevision: ">= 1.0.0",
@@ -1000,7 +1116,7 @@ func TestHelmManifestFromChartRepoWithValueFile(t *testing.T) {
 // This is a Helm first-class app with a values file outside the repo directory
 // (`~/go/src/github.com/argoproj/argo-cd/reposerver/repository`), so it is not allowed
 func TestHelmManifestFromChartRepoWithValueFileOutsideRepo(t *testing.T) {
-	service := newService(".")
+	service := newService(t, ".")
 	source := &argoappv1.ApplicationSource{
 		Chart:          "my-chart",
 		TargetRevision: ">= 1.0.0",
@@ -1015,7 +1131,7 @@ func TestHelmManifestFromChartRepoWithValueFileOutsideRepo(t *testing.T) {
 
 func TestHelmManifestFromChartRepoWithValueFileLinks(t *testing.T) {
 	t.Run("Valid symlink", func(t *testing.T) {
-		service := newService(".")
+		service := newService(t, ".")
 		source := &argoappv1.ApplicationSource{
 			Chart:          "my-chart",
 			TargetRevision: ">= 1.0.0",
@@ -1031,7 +1147,7 @@ func TestHelmManifestFromChartRepoWithValueFileLinks(t *testing.T) {
 }
 
 func TestGenerateHelmWithURL(t *testing.T) {
-	service := newService("../../util/helm/testdata/redis")
+	service := newService(t, "../../util/helm/testdata/redis")
 
 	_, err := service.GenerateManifest(context.Background(), &apiclient.ManifestRequest{
 		Repo:    &argoappv1.Repository{},
@@ -1054,7 +1170,7 @@ func TestGenerateHelmWithURL(t *testing.T) {
 // (`~/go/src/github.com/argoproj/argo-cd/util/helm/testdata/redis`), so it is blocked
 func TestGenerateHelmWithValuesDirectoryTraversalOutsideRepo(t *testing.T) {
 	t.Run("Values file with relative path pointing outside repo root", func(t *testing.T) {
-		service := newService("../../util/helm/testdata/redis")
+		service := newService(t, "../../util/helm/testdata/redis")
 		_, err := service.GenerateManifest(context.Background(), &apiclient.ManifestRequest{
 			Repo:    &argoappv1.Repository{},
 			AppName: "test",
@@ -1073,7 +1189,7 @@ func TestGenerateHelmWithValuesDirectoryTraversalOutsideRepo(t *testing.T) {
 	})
 
 	t.Run("Values file with relative path pointing inside repo root", func(t *testing.T) {
-		service := newService("./testdata")
+		service := newService(t, "./testdata")
 		_, err := service.GenerateManifest(context.Background(), &apiclient.ManifestRequest{
 			Repo:    &argoappv1.Repository{},
 			AppName: "test",
@@ -1091,7 +1207,7 @@ func TestGenerateHelmWithValuesDirectoryTraversalOutsideRepo(t *testing.T) {
 	})
 
 	t.Run("Values file with absolute path stays within repo root", func(t *testing.T) {
-		service := newService("./testdata")
+		service := newService(t, "./testdata")
 		_, err := service.GenerateManifest(context.Background(), &apiclient.ManifestRequest{
 			Repo:    &argoappv1.Repository{},
 			AppName: "test",
@@ -1109,7 +1225,7 @@ func TestGenerateHelmWithValuesDirectoryTraversalOutsideRepo(t *testing.T) {
 	})
 
 	t.Run("Values file with absolute path using back-references outside repo root", func(t *testing.T) {
-		service := newService("./testdata")
+		service := newService(t, "./testdata")
 		_, err := service.GenerateManifest(context.Background(), &apiclient.ManifestRequest{
 			Repo:    &argoappv1.Repository{},
 			AppName: "test",
@@ -1128,7 +1244,7 @@ func TestGenerateHelmWithValuesDirectoryTraversalOutsideRepo(t *testing.T) {
 	})
 
 	t.Run("Remote values file from forbidden protocol", func(t *testing.T) {
-		service := newService("./testdata")
+		service := newService(t, "./testdata")
 		_, err := service.GenerateManifest(context.Background(), &apiclient.ManifestRequest{
 			Repo:    &argoappv1.Repository{},
 			AppName: "test",
@@ -1147,7 +1263,7 @@ func TestGenerateHelmWithValuesDirectoryTraversalOutsideRepo(t *testing.T) {
 	})
 
 	t.Run("Remote values file from custom allowed protocol", func(t *testing.T) {
-		service := newService("./testdata")
+		service := newService(t, "./testdata")
 		_, err := service.GenerateManifest(context.Background(), &apiclient.ManifestRequest{
 			Repo:    &argoappv1.Repository{},
 			AppName: "test",
@@ -1168,7 +1284,7 @@ func TestGenerateHelmWithValuesDirectoryTraversalOutsideRepo(t *testing.T) {
 
 // File parameter should not allow traversal outside of the repository root
 func TestGenerateHelmWithAbsoluteFileParameter(t *testing.T) {
-	service := newService("../..")
+	service := newService(t, "../..")
 
 	file, err := os.CreateTemp("", "external-secret.txt")
 	assert.NoError(t, err)
@@ -1209,7 +1325,7 @@ func TestGenerateHelmWithAbsoluteFileParameter(t *testing.T) {
 // directory (`~/go/src/github.com/argoproj/argo-cd`), it is allowed. It is used as a means of
 // providing direct content to a helm chart via a specific key.
 func TestGenerateHelmWithFileParameter(t *testing.T) {
-	service := newService("../../util/helm/testdata")
+	service := newService(t, "../../util/helm/testdata")
 
 	res, err := service.GenerateManifest(context.Background(), &apiclient.ManifestRequest{
 		Repo:    &argoappv1.Repository{},
@@ -1234,7 +1350,7 @@ func TestGenerateHelmWithFileParameter(t *testing.T) {
 }
 
 func TestGenerateNullList(t *testing.T) {
-	service := newService(".")
+	service := newService(t, ".")
 
 	t.Run("null list", func(t *testing.T) {
 		res1, err := service.GenerateManifest(context.Background(), &apiclient.ManifestRequest{
@@ -1302,7 +1418,7 @@ func TestGenerateFromUTF16(t *testing.T) {
 }
 
 func TestListApps(t *testing.T) {
-	service := newService("./testdata")
+	service := newService(t, "./testdata")
 
 	res, err := service.ListApps(context.Background(), &apiclient.ListAppsRequest{Repo: &argoappv1.Repository{}})
 	assert.NoError(t, err)
@@ -1329,7 +1445,7 @@ func TestListApps(t *testing.T) {
 }
 
 func TestGetAppDetailsHelm(t *testing.T) {
-	service := newService("../../util/helm/testdata/dependency")
+	service := newService(t, "../../util/helm/testdata/dependency")
 
 	res, err := service.GetAppDetails(context.Background(), &apiclient.RepoServerAppDetailsQuery{
 		Repo: &argoappv1.Repository{},
@@ -1344,8 +1460,26 @@ func TestGetAppDetailsHelm(t *testing.T) {
 	assert.Equal(t, "Helm", res.Type)
 	assert.EqualValues(t, []string{"values-production.yaml", "values.yaml"}, res.Helm.ValueFiles)
 }
+
+func TestGetAppDetailsHelmUsesCache(t *testing.T) {
+	service := newService(t, "../../util/helm/testdata/dependency")
+
+	res, err := service.GetAppDetails(context.Background(), &apiclient.RepoServerAppDetailsQuery{
+		Repo: &argoappv1.Repository{},
+		Source: &argoappv1.ApplicationSource{
+			Path: ".",
+		},
+	})
+
+	assert.NoError(t, err)
+	assert.NotNil(t, res.Helm)
+
+	assert.Equal(t, "Helm", res.Type)
+	assert.EqualValues(t, []string{"values-production.yaml", "values.yaml"}, res.Helm.ValueFiles)
+}
+
 func TestGetAppDetailsHelm_WithNoValuesFile(t *testing.T) {
-	service := newService("../../util/helm/testdata/api-versions")
+	service := newService(t, "../../util/helm/testdata/api-versions")
 
 	res, err := service.GetAppDetails(context.Background(), &apiclient.RepoServerAppDetailsQuery{
 		Repo: &argoappv1.Repository{},
@@ -1363,7 +1497,7 @@ func TestGetAppDetailsHelm_WithNoValuesFile(t *testing.T) {
 }
 
 func TestGetAppDetailsKustomize(t *testing.T) {
-	service := newService("../../util/kustomize/testdata/kustomization_yaml")
+	service := newService(t, "../../util/kustomize/testdata/kustomization_yaml")
 
 	res, err := service.GetAppDetails(context.Background(), &apiclient.RepoServerAppDetailsQuery{
 		Repo: &argoappv1.Repository{},
@@ -1380,7 +1514,7 @@ func TestGetAppDetailsKustomize(t *testing.T) {
 }
 
 func TestGetHelmCharts(t *testing.T) {
-	service := newService("../..")
+	service := newService(t, "../..")
 	res, err := service.GetHelmCharts(context.Background(), &apiclient.HelmChartsRequest{Repo: &argoappv1.Repository{}})
 
 	// fix flakiness
@@ -1401,7 +1535,7 @@ func TestGetHelmCharts(t *testing.T) {
 }
 
 func TestGetRevisionMetadata(t *testing.T) {
-	service, gitClient := newServiceWithMocks("../..", false)
+	service, gitClient, _ := newServiceWithMocks(t, "../..", false)
 	now := time.Now()
 
 	gitClient.On("RevisionMetadata", mock.Anything).Return(&git.RevisionMetadata{
@@ -1469,7 +1603,7 @@ func TestGetRevisionMetadata(t *testing.T) {
 func TestGetSignatureVerificationResult(t *testing.T) {
 	// Commit with signature and verification requested
 	{
-		service := newServiceWithSignature("../../manifests/base")
+		service := newServiceWithSignature(t, "../../manifests/base")
 
 		src := argoappv1.ApplicationSource{Path: "."}
 		q := apiclient.ManifestRequest{
@@ -1486,7 +1620,7 @@ func TestGetSignatureVerificationResult(t *testing.T) {
 	}
 	// Commit with signature and verification not requested
 	{
-		service := newServiceWithSignature("../../manifests/base")
+		service := newServiceWithSignature(t, "../../manifests/base")
 
 		src := argoappv1.ApplicationSource{Path: "."}
 		q := apiclient.ManifestRequest{Repo: &argoappv1.Repository{}, ApplicationSource: &src, ProjectName: "something",
@@ -1498,7 +1632,7 @@ func TestGetSignatureVerificationResult(t *testing.T) {
 	}
 	// Commit without signature and verification requested
 	{
-		service := newService("../../manifests/base")
+		service := newService(t, "../../manifests/base")
 
 		src := argoappv1.ApplicationSource{Path: "."}
 		q := apiclient.ManifestRequest{Repo: &argoappv1.Repository{}, ApplicationSource: &src, VerifySignature: true, ProjectName: "something",
@@ -1510,7 +1644,7 @@ func TestGetSignatureVerificationResult(t *testing.T) {
 	}
 	// Commit without signature and verification not requested
 	{
-		service := newService("../../manifests/base")
+		service := newService(t, "../../manifests/base")
 
 		src := argoappv1.ApplicationSource{Path: "."}
 		q := apiclient.ManifestRequest{Repo: &argoappv1.Repository{}, ApplicationSource: &src, VerifySignature: true, ProjectName: "something",
@@ -1543,7 +1677,7 @@ func Test_newEnv(t *testing.T) {
 }
 
 func TestService_newHelmClientResolveRevision(t *testing.T) {
-	service := newService(".")
+	service := newService(t, ".")
 
 	t.Run("EmptyRevision", func(t *testing.T) {
 		_, _, err := service.newHelmClientResolveRevision(&argoappv1.Repository{}, "", "", true)
@@ -1557,7 +1691,7 @@ func TestService_newHelmClientResolveRevision(t *testing.T) {
 
 func TestGetAppDetailsWithAppParameterFile(t *testing.T) {
 	t.Run("No app name set and app specific file exists", func(t *testing.T) {
-		service := newService(".")
+		service := newService(t, ".")
 		runWithTempTestdata(t, "multi", func(t *testing.T, path string) {
 			details, err := service.GetAppDetails(context.Background(), &apiclient.RepoServerAppDetailsQuery{
 				Repo: &argoappv1.Repository{},
@@ -1570,7 +1704,7 @@ func TestGetAppDetailsWithAppParameterFile(t *testing.T) {
 		})
 	})
 	t.Run("No app specific override", func(t *testing.T) {
-		service := newService(".")
+		service := newService(t, ".")
 		runWithTempTestdata(t, "single-global", func(t *testing.T, path string) {
 			details, err := service.GetAppDetails(context.Background(), &apiclient.RepoServerAppDetailsQuery{
 				Repo: &argoappv1.Repository{},
@@ -1584,7 +1718,7 @@ func TestGetAppDetailsWithAppParameterFile(t *testing.T) {
 		})
 	})
 	t.Run("Only app specific override", func(t *testing.T) {
-		service := newService(".")
+		service := newService(t, ".")
 		runWithTempTestdata(t, "single-app-only", func(t *testing.T, path string) {
 			details, err := service.GetAppDetails(context.Background(), &apiclient.RepoServerAppDetailsQuery{
 				Repo: &argoappv1.Repository{},
@@ -1598,7 +1732,7 @@ func TestGetAppDetailsWithAppParameterFile(t *testing.T) {
 		})
 	})
 	t.Run("App specific override", func(t *testing.T) {
-		service := newService(".")
+		service := newService(t, ".")
 		runWithTempTestdata(t, "multi", func(t *testing.T, path string) {
 			details, err := service.GetAppDetails(context.Background(), &apiclient.RepoServerAppDetailsQuery{
 				Repo: &argoappv1.Repository{},
@@ -1612,7 +1746,7 @@ func TestGetAppDetailsWithAppParameterFile(t *testing.T) {
 		})
 	})
 	t.Run("App specific overrides containing non-mergeable field", func(t *testing.T) {
-		service := newService(".")
+		service := newService(t, ".")
 		runWithTempTestdata(t, "multi", func(t *testing.T, path string) {
 			details, err := service.GetAppDetails(context.Background(), &apiclient.RepoServerAppDetailsQuery{
 				Repo: &argoappv1.Repository{},
@@ -1626,7 +1760,7 @@ func TestGetAppDetailsWithAppParameterFile(t *testing.T) {
 		})
 	})
 	t.Run("Broken app-specific overrides", func(t *testing.T) {
-		service := newService(".")
+		service := newService(t, ".")
 		runWithTempTestdata(t, "multi", func(t *testing.T, path string) {
 			_, err := service.GetAppDetails(context.Background(), &apiclient.RepoServerAppDetailsQuery{
 				Repo: &argoappv1.Repository{},
@@ -1668,7 +1802,7 @@ func runWithTempTestdata(t *testing.T, path string, runner func(t *testing.T, pa
 func TestGenerateManifestsWithAppParameterFile(t *testing.T) {
 	t.Run("Single global override", func(t *testing.T) {
 		runWithTempTestdata(t, "single-global", func(t *testing.T, path string) {
-			service := newService(".")
+			service := newService(t, ".")
 			manifests, err := service.GenerateManifest(context.Background(), &apiclient.ManifestRequest{
 				Repo: &argoappv1.Repository{},
 				ApplicationSource: &argoappv1.ApplicationSource{
@@ -1699,7 +1833,7 @@ func TestGenerateManifestsWithAppParameterFile(t *testing.T) {
 
 	t.Run("Single global override Helm", func(t *testing.T) {
 		runWithTempTestdata(t, "single-global-helm", func(t *testing.T, path string) {
-			service := newService(".")
+			service := newService(t, ".")
 			manifests, err := service.GenerateManifest(context.Background(), &apiclient.ManifestRequest{
 				Repo: &argoappv1.Repository{},
 				ApplicationSource: &argoappv1.ApplicationSource{
@@ -1729,7 +1863,7 @@ func TestGenerateManifestsWithAppParameterFile(t *testing.T) {
 	})
 
 	t.Run("Application specific override", func(t *testing.T) {
-		service := newService(".")
+		service := newService(t, ".")
 		runWithTempTestdata(t, "single-app-only", func(t *testing.T, path string) {
 			manifests, err := service.GenerateManifest(context.Background(), &apiclient.ManifestRequest{
 				Repo: &argoappv1.Repository{},
@@ -1760,8 +1894,29 @@ func TestGenerateManifestsWithAppParameterFile(t *testing.T) {
 		})
 	})
 
+	t.Run("Multi-source with source as ref only does not generate manifests", func(t *testing.T) {
+		service := newService(t, ".")
+		runWithTempTestdata(t, "single-app-only", func(t *testing.T, path string) {
+			manifests, err := service.GenerateManifest(context.Background(), &apiclient.ManifestRequest{
+				Repo: &argoappv1.Repository{},
+				ApplicationSource: &argoappv1.ApplicationSource{
+					Path:  "",
+					Chart: "",
+					Ref:   "test",
+				},
+				AppName:            "testapp-multi-ref-only",
+				ProjectName:        "something",
+				ProjectSourceRepos: []string{"*"},
+				HasMultipleSources: true,
+			})
+			assert.NoError(t, err)
+			assert.Empty(t, manifests.Manifests)
+			assert.NotEmpty(t, manifests.Revision)
+		})
+	})
+
 	t.Run("Application specific override for other app", func(t *testing.T) {
-		service := newService(".")
+		service := newService(t, ".")
 		runWithTempTestdata(t, "single-app-only", func(t *testing.T, path string) {
 			manifests, err := service.GenerateManifest(context.Background(), &apiclient.ManifestRequest{
 				Repo: &argoappv1.Repository{},
@@ -1793,7 +1948,7 @@ func TestGenerateManifestsWithAppParameterFile(t *testing.T) {
 	})
 
 	t.Run("Override info does not appear in cache key", func(t *testing.T) {
-		service := newService(".")
+		service := newService(t, ".")
 		runWithTempTestdata(t, "single-global", func(t *testing.T, path string) {
 			source := &argoappv1.ApplicationSource{
 				Path: path,
@@ -1843,7 +1998,7 @@ func TestGenerateManifestWithAnnotatedAndRegularGitTagHashes(t *testing.T) {
 				ProjectSourceRepos: []string{"*"},
 			},
 			wantError: false,
-			service:   newServiceWithCommitSHA(".", regularGitTagHash),
+			service:   newServiceWithCommitSHA(t, ".", regularGitTagHash),
 		},
 
 		{
@@ -1859,7 +2014,7 @@ func TestGenerateManifestWithAnnotatedAndRegularGitTagHashes(t *testing.T) {
 				ProjectSourceRepos: []string{"*"},
 			},
 			wantError: false,
-			service:   newServiceWithCommitSHA(".", annotatedGitTaghash),
+			service:   newServiceWithCommitSHA(t, ".", annotatedGitTaghash),
 		},
 
 		{
@@ -1875,7 +2030,7 @@ func TestGenerateManifestWithAnnotatedAndRegularGitTagHashes(t *testing.T) {
 				ProjectSourceRepos: []string{"*"},
 			},
 			wantError: true,
-			service:   newServiceWithCommitSHA(".", invalidGitTaghash),
+			service:   newServiceWithCommitSHA(t, ".", invalidGitTaghash),
 		},
 	}
 	for _, tt := range tests {
@@ -1900,7 +2055,7 @@ func TestGenerateManifestWithAnnotatedAndRegularGitTagHashes(t *testing.T) {
 func TestGenerateManifestWithAnnotatedTagsAndMultiSourceApp(t *testing.T) {
 	annotatedGitTaghash := "95249be61b028d566c29d47b19e65c5603388a41"
 
-	service := newServiceWithCommitSHA(".", annotatedGitTaghash)
+	service := newServiceWithCommitSHA(t, ".", annotatedGitTaghash)
 
 	refSources := map[string]*argoappv1.RefTarget{}
 
@@ -2485,7 +2640,7 @@ func Test_findManifests(t *testing.T) {
 }
 
 func TestTestRepoOCI(t *testing.T) {
-	service := newService(".")
+	service := newService(t, ".")
 	_, err := service.TestRepository(context.Background(), &apiclient.TestRepositoryRequest{
 		Repo: &argoappv1.Repository{
 			Repo:      "https://demo.goharbor.io",
@@ -2510,7 +2665,7 @@ func Test_getHelmDependencyRepos(t *testing.T) {
 
 func TestResolveRevision(t *testing.T) {
 
-	service := newService(".")
+	service := newService(t, ".")
 	repo := &argoappv1.Repository{Repo: "https://github.com/argoproj/argo-cd"}
 	app := &argoappv1.Application{Spec: argoappv1.ApplicationSpec{Source: &argoappv1.ApplicationSource{}}}
 	resolveRevisionResponse, err := service.ResolveRevision(context.Background(), &apiclient.ResolveRevisionRequest{
@@ -2532,7 +2687,7 @@ func TestResolveRevision(t *testing.T) {
 
 func TestResolveRevisionNegativeScenarios(t *testing.T) {
 
-	service := newService(".")
+	service := newService(t, ".")
 	repo := &argoappv1.Repository{Repo: "https://github.com/argoproj/argo-cd"}
 	app := &argoappv1.Application{Spec: argoappv1.ApplicationSpec{Source: &argoappv1.ApplicationSource{}}}
 	resolveRevisionResponse, err := service.ResolveRevision(context.Background(), &apiclient.ResolveRevisionRequest{
@@ -2579,19 +2734,57 @@ func TestDirectoryPermissionInitializer(t *testing.T) {
 	require.Error(t, err)
 }
 
-func initGitRepo(repoPath string, remote string) error {
-	if err := os.Mkdir(repoPath, 0755); err != nil {
-		return err
+func addHelmToGitRepo(t *testing.T, options newGitRepoOptions) {
+	err := os.WriteFile(filepath.Join(options.path, "Chart.yaml"), []byte("name: test\nversion: v1.0.0"), 0777)
+	assert.NoError(t, err)
+	for valuesFileName, values := range options.helmChartOptions.valuesFiles {
+		valuesFileContents, err := yaml.Marshal(values)
+		assert.NoError(t, err)
+		err = os.WriteFile(filepath.Join(options.path, valuesFileName), valuesFileContents, 0777)
+		assert.NoError(t, err)
+	}
+	assert.NoError(t, err)
+	cmd := exec.Command("git", "add", "-A")
+	cmd.Dir = options.path
+	assert.NoError(t, cmd.Run())
+	cmd = exec.Command("git", "commit", "-m", "Initial commit")
+	cmd.Dir = options.path
+	assert.NoError(t, cmd.Run())
+}
+
+func initGitRepo(t *testing.T, options newGitRepoOptions) (revision string) {
+	if options.createPath {
+		assert.NoError(t, os.Mkdir(options.path, 0755))
 	}
 
-	cmd := exec.Command("git", "init", repoPath)
-	cmd.Dir = repoPath
-	if err := cmd.Run(); err != nil {
-		return err
+	cmd := exec.Command("git", "init", options.path)
+	cmd.Dir = options.path
+	assert.NoError(t, cmd.Run())
+
+	if options.remote != "" {
+		cmd = exec.Command("git", "remote", "add", "origin", options.path)
+		cmd.Dir = options.path
+		assert.NoError(t, cmd.Run())
 	}
-	cmd = exec.Command("git", "remote", "add", "origin", remote)
-	cmd.Dir = repoPath
-	return cmd.Run()
+
+	commitAdded := options.addEmptyCommit || options.helmChartOptions.chartName != ""
+	if options.addEmptyCommit {
+		cmd = exec.Command("git", "commit", "-m", "Initial commit", "--allow-empty")
+		cmd.Dir = options.path
+		assert.NoError(t, cmd.Run())
+	} else if options.helmChartOptions.chartName != "" {
+		addHelmToGitRepo(t, options)
+	}
+
+	if commitAdded {
+		var revB bytes.Buffer
+		cmd = exec.Command("git", "rev-parse", "HEAD", options.path)
+		cmd.Dir = options.path
+		cmd.Stdout = &revB
+		assert.NoError(t, cmd.Run())
+		revision = strings.Split(revB.String(), "\n")[0]
+	}
+	return revision
 }
 
 func TestInit(t *testing.T) {
@@ -2604,16 +2797,16 @@ func TestInit(t *testing.T) {
 	})
 
 	repoPath := path.Join(dir, "repo1")
-	require.NoError(t, initGitRepo(repoPath, "https://github.com/argo-cd/test-repo1"))
+	initGitRepo(t, newGitRepoOptions{path: repoPath, remote: "https://github.com/argo-cd/test-repo1", createPath: true, addEmptyCommit: false})
 
-	service := newService(".")
+	service := newService(t, ".")
 	service.rootDir = dir
 
 	require.NoError(t, service.Init())
 
 	_, err := os.ReadDir(dir)
 	require.Error(t, err)
-	require.NoError(t, initGitRepo(path.Join(dir, "repo2"), "https://github.com/argo-cd/test-repo2"))
+	initGitRepo(t, newGitRepoOptions{path: path.Join(dir, "repo2"), remote: "https://github.com/argo-cd/test-repo2", createPath: true, addEmptyCommit: false})
 }
 
 // TestCheckoutRevisionCanGetNonstandardRefs shows that we can fetch a revision that points to a non-standard ref. In
@@ -2926,7 +3119,7 @@ func TestErrorGetGitDirectories(t *testing.T) {
 		want    *apiclient.GitDirectoriesResponse
 		wantErr assert.ErrorAssertionFunc
 	}{
-		{name: "InvalidRepo", fields: fields{service: newService(".")}, args: args{
+		{name: "InvalidRepo", fields: fields{service: newService(t, ".")}, args: args{
 			ctx: context.TODO(),
 			request: &apiclient.GitDirectoriesRequest{
 				Repo:             nil,
@@ -2935,7 +3128,7 @@ func TestErrorGetGitDirectories(t *testing.T) {
 			},
 		}, want: nil, wantErr: assert.Error},
 		{name: "InvalidResolveRevision", fields: fields{service: func() *Service {
-			s, _ := newServiceWithOpt(func(gitClient *gitmocks.Client, helmClient *helmmocks.Client, paths *iomocks.TempPaths) {
+			s, _, _ := newServiceWithOpt(t, func(gitClient *gitmocks.Client, helmClient *helmmocks.Client, paths *iomocks.TempPaths) {
 				gitClient.On("Checkout", mock.Anything, mock.Anything).Return(nil)
 				gitClient.On("LsRemote", mock.Anything).Return("", fmt.Errorf("ah error"))
 				paths.On("GetPath", mock.Anything).Return(".", nil)
@@ -2966,7 +3159,7 @@ func TestErrorGetGitDirectories(t *testing.T) {
 func TestGetGitDirectories(t *testing.T) {
 	// test not using the cache
 	root := "./testdata/git-files-dirs"
-	s, _ := newServiceWithOpt(func(gitClient *gitmocks.Client, helmClient *helmmocks.Client, paths *iomocks.TempPaths) {
+	s, _, cacheMocks := newServiceWithOpt(t, func(gitClient *gitmocks.Client, helmClient *helmmocks.Client, paths *iomocks.TempPaths) {
 		gitClient.On("Init").Return(nil)
 		gitClient.On("Fetch", mock.Anything).Return(nil)
 		gitClient.On("Checkout", mock.Anything, mock.Anything).Once().Return(nil)
@@ -2989,6 +3182,10 @@ func TestGetGitDirectories(t *testing.T) {
 	directories, err = s.GetGitDirectories(context.TODO(), dirRequest)
 	assert.Nil(t, err)
 	assert.ElementsMatch(t, []string{"app", "app/bar", "app/foo/bar", "somedir", "app/foo"}, directories.GetPaths())
+	cacheMocks.mockCache.AssertCacheCalledTimes(t, &repositorymocks.CacheCallCounts{
+		ExternalSets: 1,
+		ExternalGets: 2,
+	})
 }
 
 func TestErrorGetGitFiles(t *testing.T) {
@@ -3006,7 +3203,7 @@ func TestErrorGetGitFiles(t *testing.T) {
 		want    *apiclient.GitFilesResponse
 		wantErr assert.ErrorAssertionFunc
 	}{
-		{name: "InvalidRepo", fields: fields{service: newService(".")}, args: args{
+		{name: "InvalidRepo", fields: fields{service: newService(t, ".")}, args: args{
 			ctx: context.TODO(),
 			request: &apiclient.GitFilesRequest{
 				Repo:             nil,
@@ -3015,7 +3212,7 @@ func TestErrorGetGitFiles(t *testing.T) {
 			},
 		}, want: nil, wantErr: assert.Error},
 		{name: "InvalidResolveRevision", fields: fields{service: func() *Service {
-			s, _ := newServiceWithOpt(func(gitClient *gitmocks.Client, helmClient *helmmocks.Client, paths *iomocks.TempPaths) {
+			s, _, _ := newServiceWithOpt(t, func(gitClient *gitmocks.Client, helmClient *helmmocks.Client, paths *iomocks.TempPaths) {
 				gitClient.On("Checkout", mock.Anything, mock.Anything).Return(nil)
 				gitClient.On("LsRemote", mock.Anything).Return("", fmt.Errorf("ah error"))
 				paths.On("GetPath", mock.Anything).Return(".", nil)
@@ -3048,7 +3245,7 @@ func TestGetGitFiles(t *testing.T) {
 	files := []string{"./testdata/git-files-dirs/somedir/config.yaml",
 		"./testdata/git-files-dirs/config.yaml", "./testdata/git-files-dirs/config.yaml", "./testdata/git-files-dirs/app/foo/bar/config.yaml"}
 	root := ""
-	s, _ := newServiceWithOpt(func(gitClient *gitmocks.Client, helmClient *helmmocks.Client, paths *iomocks.TempPaths) {
+	s, _, cacheMocks := newServiceWithOpt(t, func(gitClient *gitmocks.Client, helmClient *helmmocks.Client, paths *iomocks.TempPaths) {
 		gitClient.On("Init").Return(nil)
 		gitClient.On("Fetch", mock.Anything).Return(nil)
 		gitClient.On("Checkout", mock.Anything, mock.Anything).Once().Return(nil)
@@ -3081,6 +3278,10 @@ func TestGetGitFiles(t *testing.T) {
 	fileResponse, err = s.GetGitFiles(context.TODO(), filesRequest)
 	assert.Nil(t, err)
 	assert.Equal(t, expected, fileResponse.GetMap())
+	cacheMocks.mockCache.AssertCacheCalledTimes(t, &repositorymocks.CacheCallCounts{
+		ExternalSets: 1,
+		ExternalGets: 2,
+	})
 }
 
 func Test_getRepoSanitizerRegex(t *testing.T) {
@@ -3089,4 +3290,46 @@ func Test_getRepoSanitizerRegex(t *testing.T) {
 	assert.Equal(t, "error message containing <path to cached source> and other stuff", msg)
 	msg = r.ReplaceAllString("error message containing /tmp/_argocd-repo/SENSITIVE/with/trailing/path and other stuff", "<path to cached source>")
 	assert.Equal(t, "error message containing <path to cached source>/with/trailing/path and other stuff", msg)
+}
+
+func TestGetRevisionChartDetails(t *testing.T) {
+	t.Run("Test revision semvar", func(t *testing.T) {
+		root := t.TempDir()
+		service := newService(t, root)
+		_, err := service.GetRevisionChartDetails(context.Background(), &apiclient.RepoServerRevisionChartDetailsRequest{
+			Repo: &v1alpha1.Repository{
+				Repo: fmt.Sprintf("file://%s", root),
+				Name: "test-repo-name",
+				Type: "helm",
+			},
+			Name:     "test-name",
+			Revision: "test-revision",
+		})
+		assert.ErrorContains(t, err, "invalid revision")
+	})
+
+	t.Run("Test GetRevisionChartDetails", func(t *testing.T) {
+		root := t.TempDir()
+		service := newService(t, root)
+		repoUrl := fmt.Sprintf("file://%s", root)
+		err := service.cache.SetRevisionChartDetails(repoUrl, "my-chart", "1.1.0", &argoappv1.ChartDetails{
+			Description: "test-description",
+			Home:        "test-home",
+			Maintainers: []string{"test-maintainer"},
+		})
+		assert.NoError(t, err)
+		chartDetails, err := service.GetRevisionChartDetails(context.Background(), &apiclient.RepoServerRevisionChartDetailsRequest{
+			Repo: &v1alpha1.Repository{
+				Repo: fmt.Sprintf("file://%s", root),
+				Name: "test-repo-name",
+				Type: "helm",
+			},
+			Name:     "my-chart",
+			Revision: "1.1.0",
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, "test-description", chartDetails.Description)
+		assert.Equal(t, "test-home", chartDetails.Home)
+		assert.Equal(t, []string{"test-maintainer"}, chartDetails.Maintainers)
+	})
 }

--- a/util/cache/appstate/cache.go
+++ b/util/cache/appstate/cache.go
@@ -37,7 +37,7 @@ func AddCacheFlagsToCmd(cmd *cobra.Command, opts ...func(client *redis.Client)) 
 	cacheFactory := cacheutil.AddCacheFlagsToCmd(cmd, opts...)
 
 	return func() (*Cache, error) {
-		cache, err := cacheFactory()
+		cache, err := cacheFactory(false)
 		if err != nil {
 			return nil, err
 		}

--- a/util/cache/appstate/cache.go
+++ b/util/cache/appstate/cache.go
@@ -46,11 +46,11 @@ func AddCacheFlagsToCmd(cmd *cobra.Command, opts ...func(client *redis.Client)) 
 }
 
 func (c *Cache) GetItem(key string, item interface{}) error {
-	return c.Cache.GetItem(key, item)
+	return c.Cache.GetItem(key, item, nil)
 }
 
 func (c *Cache) SetItem(key string, item interface{}, expiration time.Duration, delete bool) error {
-	return c.Cache.SetItem(key, item, expiration, delete)
+	return c.Cache.SetItem(key, item, &cacheutil.CacheActionOpts{Expiration: expiration, Delete: delete})
 }
 
 func appManagedResourcesKey(appName string) string {

--- a/util/cache/cache.go
+++ b/util/cache/cache.go
@@ -31,7 +31,7 @@ const (
 )
 
 func NewCache(client CacheClient) *Cache {
-	return &Cache{client}
+	return &Cache{client: client}
 }
 
 func buildRedisClient(redisAddress, password, username string, redisDB, maxRetries int, tlsConfig *tls.Config) *redis.Client {
@@ -74,7 +74,7 @@ func buildFailoverRedisClient(sentinelMaster, password, username string, redisDB
 }
 
 // AddCacheFlagsToCmd adds flags which control caching to the specified command
-func AddCacheFlagsToCmd(cmd *cobra.Command, opts ...func(client *redis.Client)) func() (*Cache, error) {
+func AddCacheFlagsToCmd(cmd *cobra.Command, opts ...func(client *redis.Client)) func(useTwoLevelCache bool) (*Cache, error) {
 	redisAddress := ""
 	sentinelAddresses := make([]string, 0)
 	sentinelMaster := ""
@@ -98,7 +98,7 @@ func AddCacheFlagsToCmd(cmd *cobra.Command, opts ...func(client *redis.Client)) 
 	cmd.Flags().BoolVar(&insecureRedis, "redis-insecure-skip-tls-verify", false, "Skip Redis server certificate validation.")
 	cmd.Flags().StringVar(&redisCACertificate, "redis-ca-certificate", "", "Path to Redis server CA certificate (e.g. /etc/certs/redis/ca.crt). If not specified, system trusted CAs will be used for server certificate validation.")
 	cmd.Flags().StringVar(&compressionStr, "redis-compress", env.StringFromEnv("REDIS_COMPRESSION", string(RedisCompressionGZip)), "Enable compression for data sent to Redis with the required compression algorithm. (possible values: gzip, none)")
-	return func() (*Cache, error) {
+	return func(useTwoLevelCache bool) (*Cache, error) {
 		var tlsConfig *tls.Config = nil
 		if redisUseTLS {
 			tlsConfig = &tls.Config{}
@@ -132,22 +132,23 @@ func AddCacheFlagsToCmd(cmd *cobra.Command, opts ...func(client *redis.Client)) 
 		if err != nil {
 			return nil, err
 		}
+		var redisClient *redis.Client
 		if len(sentinelAddresses) > 0 {
-			client := buildFailoverRedisClient(sentinelMaster, password, username, redisDB, maxRetries, tlsConfig, sentinelAddresses)
-			for i := range opts {
-				opts[i](client)
+			redisClient = buildFailoverRedisClient(sentinelMaster, password, username, redisDB, maxRetries, tlsConfig, sentinelAddresses)
+		} else {
+			if redisAddress == "" {
+				redisAddress = common.DefaultRedisAddr
 			}
-			return NewCache(NewRedisCache(client, defaultCacheExpiration, compression)), nil
+			redisClient = buildRedisClient(redisAddress, password, username, redisDB, maxRetries, tlsConfig)
 		}
-		if redisAddress == "" {
-			redisAddress = common.DefaultRedisAddr
-		}
-
-		client := buildRedisClient(redisAddress, password, username, redisDB, maxRetries, tlsConfig)
+		redisCache := NewRedisCache(redisClient, defaultCacheExpiration, compression)
 		for i := range opts {
-			opts[i](client)
+			opts[i](redisClient)
 		}
-		return NewCache(NewRedisCache(client, defaultCacheExpiration, compression)), nil
+		if useTwoLevelCache {
+			return NewCache(NewTwoLevelClient(redisCache, defaultCacheExpiration)), nil
+		}
+		return NewCache(redisCache), nil
 	}
 }
 
@@ -156,6 +157,7 @@ type Cache struct {
 	client CacheClient
 }
 
+// Returns the cache client with the given type
 func (c *Cache) GetClient() CacheClient {
 	return c.client
 }
@@ -197,7 +199,7 @@ func (c *Cache) GetItem(key string, item interface{}, opts *CacheActionOpts) err
 		return fmt.Errorf("cannot get item into a nil for key %s", key)
 	}
 	client := c.GetClient()
-	return client.Get(key, item)
+	return client.Get(&Item{Key: key, Object: item, CacheActionOpts: *opts})
 }
 
 func (c *Cache) OnUpdated(ctx context.Context, key string, callback func() error) error {

--- a/util/cache/cache.go
+++ b/util/cache/cache.go
@@ -16,6 +16,7 @@ import (
 	"github.com/argoproj/argo-cd/v2/common"
 	certutil "github.com/argoproj/argo-cd/v2/util/cert"
 	"github.com/argoproj/argo-cd/v2/util/env"
+	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -163,30 +164,46 @@ func (c *Cache) SetClient(client CacheClient) {
 	c.client = client
 }
 
-func (c *Cache) SetItem(key string, item interface{}, expiration time.Duration, delete bool) error {
-	key = fmt.Sprintf("%s|%s", key, common.CacheVersion)
-	if delete {
-		return c.client.Delete(key)
+func (c *Cache) generateFullKey(key string) string {
+	if key == "" {
+		log.Debug("Cache key is empty, this will result in key collisions if there is more than one empty key")
+	}
+	return fmt.Sprintf("%s|%s", key, common.CacheVersion)
+}
+
+// Sets or deletes an item in cache
+func (c *Cache) SetItem(key string, item interface{}, opts *CacheActionOpts) error {
+	if opts == nil {
+		opts = &CacheActionOpts{}
+	}
+	if item == nil {
+		return fmt.Errorf("cannot set nil item in cache")
+	}
+	fullKey := c.generateFullKey(key)
+	client := c.GetClient()
+	if opts.Delete {
+		return client.Delete(fullKey)
 	} else {
-		if item == nil {
-			return fmt.Errorf("cannot set item to nil for key %s", key)
-		}
-		return c.client.Set(&Item{Object: item, Key: key, Expiration: expiration})
+		return client.Set(&Item{Key: fullKey, Object: item, CacheActionOpts: *opts})
 	}
 }
 
-func (c *Cache) GetItem(key string, item interface{}) error {
+func (c *Cache) GetItem(key string, item interface{}, opts *CacheActionOpts) error {
+	if opts == nil {
+		opts = &CacheActionOpts{}
+	}
+	key = c.generateFullKey(key)
 	if item == nil {
 		return fmt.Errorf("cannot get item into a nil for key %s", key)
 	}
-	key = fmt.Sprintf("%s|%s", key, common.CacheVersion)
-	return c.client.Get(key, item)
+	client := c.GetClient()
+	return client.Get(key, item)
 }
 
 func (c *Cache) OnUpdated(ctx context.Context, key string, callback func() error) error {
-	return c.client.OnUpdated(ctx, fmt.Sprintf("%s|%s", key, common.CacheVersion), callback)
+	return c.client.OnUpdated(ctx, c.generateFullKey(key), callback)
 }
 
 func (c *Cache) NotifyUpdated(key string) error {
-	return c.client.NotifyUpdated(fmt.Sprintf("%s|%s", key, common.CacheVersion))
+	return c.client.NotifyUpdated(c.generateFullKey(key))
 }

--- a/util/cache/cache_test.go
+++ b/util/cache/cache_test.go
@@ -13,9 +13,15 @@ import (
 )
 
 func TestAddCacheFlagsToCmd(t *testing.T) {
-	cache, err := AddCacheFlagsToCmd(&cobra.Command{})()
+	cache, err := AddCacheFlagsToCmd(&cobra.Command{})(false)
 	assert.NoError(t, err)
 	assert.Equal(t, 24*time.Hour, cache.client.(*redisCache).expiration)
+}
+
+func TestAddCacheFlagsToCmdTwoLevelCache(t *testing.T) {
+	cache, err := AddCacheFlagsToCmd(&cobra.Command{})(true)
+	assert.NoError(t, err)
+	assert.Equal(t, 24*time.Hour, cache.client.(*twoLevelClient).externalCache.(*redisCache).expiration)
 }
 
 func NewInMemoryRedis() (*redis.Client, func()) {

--- a/util/cache/cache_test.go
+++ b/util/cache/cache_test.go
@@ -1,9 +1,13 @@
 package cache
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
+	"github.com/alicebob/miniredis/v2"
+	"github.com/argoproj/argo-cd/v2/common"
+	"github.com/redis/go-redis/v9"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 )
@@ -14,33 +18,73 @@ func TestAddCacheFlagsToCmd(t *testing.T) {
 	assert.Equal(t, 24*time.Hour, cache.client.(*redisCache).expiration)
 }
 
+func NewInMemoryRedis() (*redis.Client, func()) {
+	mr, err := miniredis.Run()
+	if err != nil {
+		panic(err)
+	}
+	return redis.NewClient(&redis.Options{Addr: mr.Addr()}), mr.Close
+}
+
 func TestCacheClient(t *testing.T) {
+	clientRedis, stopRedis := NewInMemoryRedis()
+	defer stopRedis()
+	redisCache := NewRedisCache(clientRedis, 5*time.Second, RedisCompressionNone)
+	clientMemCache := NewInMemoryCache(60 * time.Second)
+	twoLevelClient := NewTwoLevelClient(redisCache, 5*time.Second)
+	// Run tests for both Redis and InMemoryCache
+	for _, client := range []CacheClient{clientMemCache, redisCache, twoLevelClient} {
+		cache := NewCache(client)
+		t.Run("SetItem", func(t *testing.T) {
+			err := cache.SetItem("foo", "bar", &CacheActionOpts{Expiration: 60 * time.Second, DisableOverwrite: true, Delete: false})
+			assert.NoError(t, err)
+			var output string
+			err = cache.GetItem("foo", &output, nil)
+			assert.NoError(t, err)
+			assert.Equal(t, "bar", output)
+		})
+		t.Run("SetCacheItem W/Disable Overwrite", func(t *testing.T) {
+			err := cache.SetItem("foo", "bar", &CacheActionOpts{Expiration: 60 * time.Second, DisableOverwrite: true, Delete: false})
+			assert.NoError(t, err)
+			var output string
+			err = cache.GetItem("foo", &output, nil)
+			assert.NoError(t, err)
+			assert.Equal(t, "bar", output)
+			err = cache.SetItem("foo", "bar", &CacheActionOpts{Expiration: 60 * time.Second, DisableOverwrite: true, Delete: false})
+			assert.NoError(t, err)
+			err = cache.GetItem("foo", &output, nil)
+			assert.NoError(t, err)
+			assert.Equal(t, "bar", output, "output should not have changed with DisableOverwrite set to true")
+		})
+		t.Run("GetItem", func(t *testing.T) {
+			var val string
+			err := cache.GetItem("foo", &val, nil)
+			assert.NoError(t, err)
+			assert.Equal(t, "bar", val)
+		})
+		t.Run("DeleteItem", func(t *testing.T) {
+			err := cache.SetItem("foo", "bar", &CacheActionOpts{Expiration: 0, Delete: true})
+			assert.NoError(t, err)
+			var val string
+			err = cache.GetItem("foo", &val, nil)
+			assert.Error(t, err)
+			assert.Empty(t, val)
+		})
+		t.Run("Check for nil items", func(t *testing.T) {
+			err := cache.SetItem("foo", nil, &CacheActionOpts{Expiration: 0, Delete: true})
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "cannot set nil item")
+			err = cache.GetItem("foo", nil, nil)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "cannot get item")
+		})
+	}
+}
+
+// Smoke test to ensure key changes aren't done accidentally
+func TestGenerateCacheKey(t *testing.T) {
 	client := NewInMemoryCache(60 * time.Second)
 	cache := NewCache(client)
-	t.Run("SetItem", func(t *testing.T) {
-		err := cache.SetItem("foo", "bar", 60*time.Second, false)
-		assert.NoError(t, err)
-	})
-	t.Run("GetItem", func(t *testing.T) {
-		var val string
-		err := cache.GetItem("foo", &val)
-		assert.NoError(t, err)
-		assert.Equal(t, "bar", val)
-	})
-	t.Run("DeleteItem", func(t *testing.T) {
-		err := cache.SetItem("foo", "bar", 0, true)
-		assert.NoError(t, err)
-		var val string
-		err = cache.GetItem("foo", &val)
-		assert.Error(t, err)
-		assert.Empty(t, val)
-	})
-	t.Run("Check for nil items", func(t *testing.T) {
-		err := cache.SetItem("foo", nil, 0, false)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "cannot set item")
-		err = cache.GetItem("foo", nil)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "cannot get item")
-	})
+	testKey := cache.generateFullKey("testkey")
+	assert.Equal(t, fmt.Sprintf("testkey|%s", common.CacheVersion), testKey)
 }

--- a/util/cache/client.go
+++ b/util/cache/client.go
@@ -10,11 +10,14 @@ var ErrCacheMiss = errors.New("cache: key is missing")
 var ErrCacheKeyLocked = errors.New("cache: key is locked")
 var CacheLockedValue = "locked"
 
-type Item struct {
-	Key    string
-	Object interface{}
-	CacheActionOpts
-}
+type CacheType int
+
+const (
+	CacheTypeDefault CacheType = iota
+	CacheTypeInMemory
+	CacheTypeTwoLevel
+	CacheTypeExternal
+)
 
 type CacheActionOpts struct {
 	// Delete item from cache
@@ -23,11 +26,19 @@ type CacheActionOpts struct {
 	DisableOverwrite bool
 	// Expiration is the cache expiration time.
 	Expiration time.Duration
+	// Determines the cache type to use in case of two level cache, Default == Two Level(in-memory + external)
+	CacheType CacheType
+}
+
+type Item struct {
+	Key    string
+	Object interface{}
+	CacheActionOpts
 }
 
 type CacheClient interface {
 	Set(item *Item) error
-	Get(key string, obj interface{}) error
+	Get(item *Item) error
 	Delete(key string) error
 	OnUpdated(ctx context.Context, key string, callback func() error) error
 	NotifyUpdated(key string) error

--- a/util/cache/client.go
+++ b/util/cache/client.go
@@ -7,10 +7,20 @@ import (
 )
 
 var ErrCacheMiss = errors.New("cache: key is missing")
+var ErrCacheKeyLocked = errors.New("cache: key is locked")
+var CacheLockedValue = "locked"
 
 type Item struct {
 	Key    string
 	Object interface{}
+	CacheActionOpts
+}
+
+type CacheActionOpts struct {
+	// Delete item from cache
+	Delete bool
+	// Disable writing if key already exists (NX)
+	DisableOverwrite bool
 	// Expiration is the cache expiration time.
 	Expiration time.Duration
 }

--- a/util/cache/client_test.go
+++ b/util/cache/client_test.go
@@ -15,7 +15,7 @@ type testStruct struct {
 func TestCache(t *testing.T) {
 	c := NewInMemoryCache(time.Hour)
 	var obj testStruct
-	err := c.Get("key", &obj)
+	err := c.Get(&Item{Key: "key", Object: &obj})
 	assert.Equal(t, err, ErrCacheMiss)
 	cacheObj := testStruct{
 		Foo: "foo",
@@ -26,13 +26,13 @@ func TestCache(t *testing.T) {
 		Object: &cacheObj,
 	})
 	cacheObj.Foo = "baz"
-	err = c.Get("key", &obj)
+	err = c.Get(&Item{Key: "key", Object: &obj})
 	assert.Nil(t, err)
 	assert.EqualValues(t, obj.Foo, "foo")
 	assert.EqualValues(t, string(obj.Bar), "bar")
 
 	err = c.Delete("key")
 	assert.Nil(t, err)
-	err = c.Get("key", &obj)
+	err = c.Get(&Item{Key: "key", Object: &obj})
 	assert.Equal(t, err, ErrCacheMiss)
 }

--- a/util/cache/inmemory.go
+++ b/util/cache/inmemory.go
@@ -57,13 +57,13 @@ func (i *InMemoryCache) HasSame(key string, obj interface{}) (bool, error) {
 	return bytes.Equal(buf.Bytes(), existingBuf.Bytes()), nil
 }
 
-func (i *InMemoryCache) Get(key string, obj interface{}) error {
-	bufIf, found := i.memCache.Get(key)
+func (i *InMemoryCache) Get(item *Item) error {
+	bufIf, found := i.memCache.Get(item.Key)
 	if !found {
 		return ErrCacheMiss
 	}
 	buf := bufIf.(bytes.Buffer)
-	return gob.NewDecoder(&buf).Decode(obj)
+	return gob.NewDecoder(&buf).Decode(item.Object)
 }
 
 func (i *InMemoryCache) Delete(key string) error {

--- a/util/cache/inmemory.go
+++ b/util/cache/inmemory.go
@@ -29,7 +29,12 @@ func (i *InMemoryCache) Set(item *Item) error {
 	if err != nil {
 		return err
 	}
-	i.memCache.Set(item.Key, buf, item.Expiration)
+	if item.DisableOverwrite {
+		// go-redis doesn't throw an error on Set with NX, so absorbing here to keep the interface consistent
+		_ = i.memCache.Add(item.Key, buf, item.Expiration)
+	} else {
+		i.memCache.Set(item.Key, buf, item.Expiration)
+	}
 	return nil
 }
 

--- a/util/cache/inmemory_test.go
+++ b/util/cache/inmemory_test.go
@@ -16,12 +16,12 @@ func TestInMemoryCache(t *testing.T) {
 	// https://stackoverflow.com/questions/46671636/gob-decode-giving-decodevalue-of-unassignable-value-error
 	obj := &foo{}
 	// cache miss
-	err := cache.Get("my-key", obj)
+	err := cache.Get(&Item{Key: "my-key", Object: obj})
 	assert.Equal(t, ErrCacheMiss, err)
 	// cache hit
 	err = cache.Set(&Item{Key: "my-key", Object: &foo{Bar: "bar"}})
 	assert.NoError(t, err)
-	err = cache.Get("my-key", obj)
+	err = cache.Get(&Item{Key: "my-key", Object: obj})
 	assert.NoError(t, err)
 	assert.Equal(t, &foo{Bar: "bar"}, obj)
 }

--- a/util/cache/mocks/cacheclient.go
+++ b/util/cache/mocks/cacheclient.go
@@ -1,0 +1,65 @@
+package mocks
+
+import (
+	"context"
+	"time"
+
+	cache "github.com/argoproj/argo-cd/v2/util/cache"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockCacheClient struct {
+	mock.Mock
+	BaseCache  cache.CacheClient
+	ReadDelay  time.Duration
+	WriteDelay time.Duration
+}
+
+func (c *MockCacheClient) Set(item *cache.Item) error {
+	args := c.Called(item)
+	if len(args) > 0 && args.Get(0) != nil {
+		return args.Get(0).(error)
+	}
+	if c.WriteDelay > 0 {
+		time.Sleep(c.WriteDelay)
+	}
+	return c.BaseCache.Set(item)
+}
+
+func (c *MockCacheClient) Get(key string, obj interface{}) error {
+	args := c.Called(key, obj)
+	if len(args) > 0 && args.Get(0) != nil {
+		return args.Get(0).(error)
+	}
+	if c.ReadDelay > 0 {
+		time.Sleep(c.ReadDelay)
+	}
+	return c.BaseCache.Get(key, obj)
+}
+
+func (c *MockCacheClient) Delete(key string) error {
+	args := c.Called(key)
+	if len(args) > 0 && args.Get(0) != nil {
+		return args.Get(0).(error)
+	}
+	if c.WriteDelay > 0 {
+		time.Sleep(c.WriteDelay)
+	}
+	return c.BaseCache.Delete(key)
+}
+
+func (c *MockCacheClient) OnUpdated(ctx context.Context, key string, callback func() error) error {
+	args := c.Called(ctx, key, callback)
+	if len(args) > 0 && args.Get(0) != nil {
+		return args.Get(0).(error)
+	}
+	return c.BaseCache.OnUpdated(ctx, key, callback)
+}
+
+func (c *MockCacheClient) NotifyUpdated(key string) error {
+	args := c.Called(key)
+	if len(args) > 0 && args.Get(0) != nil {
+		return args.Get(0).(error)
+	}
+	return c.BaseCache.NotifyUpdated(key)
+}

--- a/util/cache/mocks/cacheclient.go
+++ b/util/cache/mocks/cacheclient.go
@@ -26,15 +26,15 @@ func (c *MockCacheClient) Set(item *cache.Item) error {
 	return c.BaseCache.Set(item)
 }
 
-func (c *MockCacheClient) Get(key string, obj interface{}) error {
-	args := c.Called(key, obj)
+func (c *MockCacheClient) Get(item *cache.Item) error {
+	args := c.Called(item)
 	if len(args) > 0 && args.Get(0) != nil {
 		return args.Get(0).(error)
 	}
 	if c.ReadDelay > 0 {
 		time.Sleep(c.ReadDelay)
 	}
-	return c.BaseCache.Get(key, obj)
+	return c.BaseCache.Get(item)
 }
 
 func (c *MockCacheClient) Delete(key string) error {

--- a/util/cache/redis.go
+++ b/util/cache/redis.go
@@ -110,6 +110,7 @@ func (r *redisCache) Set(item *Item) error {
 		Key:   r.getKey(item.Key),
 		Value: val,
 		TTL:   expiration,
+		SetNX: item.DisableOverwrite,
 	})
 }
 

--- a/util/cache/redis.go
+++ b/util/cache/redis.go
@@ -114,16 +114,16 @@ func (r *redisCache) Set(item *Item) error {
 	})
 }
 
-func (r *redisCache) Get(key string, obj interface{}) error {
+func (r *redisCache) Get(item *Item) error {
 	var data []byte
-	err := r.cache.Get(context.TODO(), r.getKey(key), &data)
+	err := r.cache.Get(context.TODO(), r.getKey(item.Key), &data)
 	if err == rediscache.ErrCacheMiss {
 		err = ErrCacheMiss
 	}
 	if err != nil {
 		return err
 	}
-	return r.unmarshal(data, obj)
+	return r.unmarshal(data, item.Object)
 }
 
 func (r *redisCache) Delete(key string) error {

--- a/util/cache/redis_test.go
+++ b/util/cache/redis_test.go
@@ -27,7 +27,7 @@ func TestRedisSetCache(t *testing.T) {
 	t.Run("Successful get", func(t *testing.T) {
 		var res string
 		client := NewRedisCache(redis.NewClient(&redis.Options{Addr: mr.Addr()}), 10*time.Second, RedisCompressionNone)
-		err = client.Get("foo", &res)
+		err = client.Get(&Item{Key: "foo", Object: &res})
 		assert.NoError(t, err)
 		assert.Equal(t, res, "bar")
 	})
@@ -41,7 +41,7 @@ func TestRedisSetCache(t *testing.T) {
 	t.Run("Cache miss", func(t *testing.T) {
 		var res string
 		client := NewRedisCache(redis.NewClient(&redis.Options{Addr: mr.Addr()}), 10*time.Second, RedisCompressionNone)
-		err = client.Get("foo", &res)
+		err = client.Get(&Item{Key: "foo", Object: &res})
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "cache: key is missing")
 	})
@@ -66,7 +66,7 @@ func TestRedisSetCacheCompressed(t *testing.T) {
 	assert.True(t, len(compressedData) > len([]byte(testValue)), "compressed data is bigger than uncompressed")
 
 	var result string
-	assert.NoError(t, client.Get("my-key", &result))
+	assert.NoError(t, client.Get(&Item{Key: "my-key", Object: &result}))
 
 	assert.Equal(t, testValue, result)
 }

--- a/util/git/client_test.go
+++ b/util/git/client_test.go
@@ -20,14 +20,23 @@ func runCmd(workingDir string, name string, args ...string) error {
 	return cmd.Run()
 }
 
-func Test_nativeGitClient_Fetch(t *testing.T) {
+func _createEmptyGitRepo() (string, error) {
 	tempDir, err := os.MkdirTemp("", "")
-	require.NoError(t, err)
+	if err != nil {
+		return tempDir, err
+	}
 
 	err = runCmd(tempDir, "git", "init")
-	require.NoError(t, err)
+	if err != nil {
+		return tempDir, err
+	}
 
 	err = runCmd(tempDir, "git", "commit", "-m", "Initial commit", "--allow-empty")
+	return tempDir, err
+}
+
+func Test_nativeGitClient_Fetch(t *testing.T) {
+	tempDir, err := _createEmptyGitRepo()
 	require.NoError(t, err)
 
 	client, err := NewClient(fmt.Sprintf("file://%s", tempDir), NopCreds{}, true, false, "")
@@ -41,13 +50,7 @@ func Test_nativeGitClient_Fetch(t *testing.T) {
 }
 
 func Test_nativeGitClient_Fetch_Prune(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "")
-	require.NoError(t, err)
-
-	err = runCmd(tempDir, "git", "init")
-	require.NoError(t, err)
-
-	err = runCmd(tempDir, "git", "commit", "-m", "Initial commit", "--allow-empty")
+	tempDir, err := _createEmptyGitRepo()
 	require.NoError(t, err)
 
 	client, err := NewClient(fmt.Sprintf("file://%s", tempDir), NopCreds{}, true, false, "")


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Fixes #14725

Fourth part of a split of the https://github.com/argoproj/argo-cd/pull/16309 and follow-up to https://github.com/argoproj/argo-cd/pull/16410

Another piece of the fixes for #14725. This PR improves the cache performance and removes the added overhead from introducing the cache level lock to solve the excess ls-remote calls

- Extends the `CacheActionOpts` introduced in [part 3](https://github.com/nromriell/argo-cd/pull/2) to add `CacheType`. This field can be used to skip the local in-memory or external cache allowing us to replace current redis only caches with two level caches in place without having to swap everything over to using both. 
- Swaps the cache type for reposerver/cache to two level cache
- Adds logic to two level cache to support the `CacheType` action option
- Modifies the Cache interface to move the `Get` call to match the `Set` call interface with just a single `Item` input which accepts the action options.

Baseline v2.9.0 with 200 multi-source applications with a ref only source:
![Screenshot from 2023-11-18 18-24-30](https://github.com/argoproj/argo-cd/assets/20120766/3a6b49d8-eb07-4aa9-8e8a-728c53520c63)

With all of the changes from the original PR:
![Screenshot from 2023-11-18 19-33-39](https://github.com/nromriell/argo-cd/assets/20120766/c94fb657-791f-4761-aee0-5cab433f0a4a)


Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [X] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [X] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [X] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [X] Does this PR require documentation updates?
* [X] I've updated documentation as required by this PR.
* [X] Optional. My organization is added to USERS.md.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [X] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [X] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [X] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [X] I have added a brief description of why this PR is necessary and/or what this PR solves.

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
